### PR TITLE
Enable testSendAndWaitThrowsOnTimeout in CI

### DIFF
--- a/src/test/java/com/github/copilot/sdk/CopilotSessionTest.java
+++ b/src/test/java/com/github/copilot/sdk/CopilotSessionTest.java
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import com.github.copilot.sdk.events.AbstractSessionEvent;
 import com.github.copilot.sdk.events.AbortEvent;
@@ -487,12 +486,9 @@ public class CopilotSessionTest {
         }
     }
 
-    // Skip in CI - this test validates client-side timeout behavior, not LLM
-    // responses.
-    // The test intentionally times out before receiving a response, so there's no
-    // snapshot to replay.
+    // This test validates client-side timeout behavior. The snapshot has no
+    // assistant response because the test expects timeout BEFORE completion.
     @Test
-    @DisabledIfEnvironmentVariable(named = "CI", matches = ".*")
     void testSendAndWaitThrowsOnTimeout() throws Exception {
         ctx.configureForTest("session", "sendandwait_throws_on_timeout");
 


### PR DESCRIPTION
- Enhanced CapiProxy.isAlive() to include HTTP health check
- When proxy crashes (e.g., due to no cached response), the HTTP check detects it and triggers automatic restart
- Removed @DisabledIfEnvironmentVariable annotation from timeout test
- All 80 tests now pass in CI mode

The upstream Node.js harness has a bug where it crashes on 'no cached response' due to missing 'return' after exitWithNoMatchingRequestError. This fix works around it by detecting the crashed proxy and restarting.