### PR TITLE
Refactor: use var for local variable type inference

### DIFF
--- a/src/main/java/com/github/copilot/sdk/CopilotClient.java
+++ b/src/main/java/com/github/copilot/sdk/CopilotClient.java
@@ -281,14 +281,13 @@ public final class CopilotClient implements AutoCloseable {
 
                 ToolDefinition tool = session.getTool(toolName);
                 if (tool == null || tool.getHandler() == null) {
-                    ToolResultObject result = new ToolResultObject()
-                            .setTextResultForLlm("Tool '" + toolName + "' is not supported.").setResultType("failure")
-                            .setError("tool '" + toolName + "' not supported");
+                    var result = new ToolResultObject().setTextResultForLlm("Tool '" + toolName + "' is not supported.")
+                            .setResultType("failure").setError("tool '" + toolName + "' not supported");
                     rpc.sendResponse(Long.parseLong(requestId), Map.of("result", result));
                     return;
                 }
 
-                ToolInvocation invocation = new ToolInvocation().setSessionId(sessionId).setToolCallId(toolCallId)
+                var invocation = new ToolInvocation().setSessionId(sessionId).setToolCallId(toolCallId)
                         .setToolName(toolName).setArguments(arguments);
 
                 tool.getHandler().invoke(invocation).thenAccept(result -> {
@@ -306,7 +305,7 @@ public final class CopilotClient implements AutoCloseable {
                     }
                 }).exceptionally(ex -> {
                     try {
-                        ToolResultObject result = new ToolResultObject()
+                        var result = new ToolResultObject()
                                 .setTextResultForLlm(
                                         "Invoking this tool produced an error. Detailed information is not available.")
                                 .setResultType("failure").setError(ex.getMessage());
@@ -335,7 +334,7 @@ public final class CopilotClient implements AutoCloseable {
 
                 CopilotSession session = sessions.get(sessionId);
                 if (session == null) {
-                    PermissionRequestResult result = new PermissionRequestResult()
+                    var result = new PermissionRequestResult()
                             .setKind("denied-no-approval-rule-and-could-not-request-from-user");
                     rpc.sendResponse(Long.parseLong(requestId), Map.of("result", result));
                     return;
@@ -349,7 +348,7 @@ public final class CopilotClient implements AutoCloseable {
                     }
                 }).exceptionally(ex -> {
                     try {
-                        PermissionRequestResult result = new PermissionRequestResult()
+                        var result = new PermissionRequestResult()
                                 .setKind("denied-no-approval-rule-and-could-not-request-from-user");
                         rpc.sendResponse(Long.parseLong(requestId), Map.of("result", result));
                     } catch (IOException e) {
@@ -381,10 +380,9 @@ public final class CopilotClient implements AutoCloseable {
                     return;
                 }
 
-                com.github.copilot.sdk.json.UserInputRequest request = new com.github.copilot.sdk.json.UserInputRequest()
-                        .setQuestion(question);
+                var request = new com.github.copilot.sdk.json.UserInputRequest().setQuestion(question);
                 if (choicesNode != null && choicesNode.isArray()) {
-                    List<String> choices = new ArrayList<>();
+                    var choices = new ArrayList<String>();
                     for (JsonNode choice : choicesNode) {
                         choices.add(choice.asText());
                     }
@@ -461,7 +459,7 @@ public final class CopilotClient implements AutoCloseable {
 
     private void verifyProtocolVersion(Connection connection) throws Exception {
         int expectedVersion = SdkProtocolVersion.get();
-        Map<String, Object> params = new HashMap<>();
+        var params = new HashMap<String, Object>();
         params.put("message", null);
         PingResponse pingResponse = connection.rpc.invoke("ping", params, PingResponse.class).get(30, TimeUnit.SECONDS);
 
@@ -484,7 +482,7 @@ public final class CopilotClient implements AutoCloseable {
      * @return A future that completes when the client is stopped
      */
     public CompletableFuture<Void> stop() {
-        List<CompletableFuture<Void>> closeFutures = new ArrayList<>();
+        var closeFutures = new ArrayList<CompletableFuture<Void>>();
 
         for (CopilotSession session : new ArrayList<>(sessions.values())) {
             closeFutures.add(CompletableFuture.runAsync(() -> {
@@ -555,7 +553,7 @@ public final class CopilotClient implements AutoCloseable {
      */
     public CompletableFuture<CopilotSession> createSession(SessionConfig config) {
         return ensureConnected().thenCompose(connection -> {
-            CreateSessionRequest request = new CreateSessionRequest();
+            var request = new CreateSessionRequest();
             if (config != null) {
                 request.setModel(config.getModel());
                 request.setSessionId(config.getSessionId());
@@ -585,8 +583,7 @@ public final class CopilotClient implements AutoCloseable {
             }
 
             return connection.rpc.invoke("session.create", request, CreateSessionResponse.class).thenApply(response -> {
-                CopilotSession session = new CopilotSession(response.getSessionId(), connection.rpc,
-                        response.getWorkspacePath());
+                var session = new CopilotSession(response.getSessionId(), connection.rpc, response.getWorkspacePath());
                 if (config != null && config.getTools() != null) {
                     session.registerTools(config.getTools());
                 }
@@ -632,7 +629,7 @@ public final class CopilotClient implements AutoCloseable {
      */
     public CompletableFuture<CopilotSession> resumeSession(String sessionId, ResumeSessionConfig config) {
         return ensureConnected().thenCompose(connection -> {
-            ResumeSessionRequest request = new ResumeSessionRequest();
+            var request = new ResumeSessionRequest();
             request.setSessionId(sessionId);
             if (config != null) {
                 request.setReasoningEffort(config.getReasoningEffort());
@@ -655,8 +652,7 @@ public final class CopilotClient implements AutoCloseable {
             }
 
             return connection.rpc.invoke("session.resume", request, ResumeSessionResponse.class).thenApply(response -> {
-                CopilotSession session = new CopilotSession(response.getSessionId(), connection.rpc,
-                        response.getWorkspacePath());
+                var session = new CopilotSession(response.getSessionId(), connection.rpc, response.getWorkspacePath());
                 if (config != null && config.getTools() != null) {
                     session.registerTools(config.getTools());
                 }
@@ -960,7 +956,7 @@ public final class CopilotClient implements AutoCloseable {
 
     private ProcessInfo startCliServer() throws IOException, InterruptedException {
         String cliPath = options.getCliPath() != null ? options.getCliPath() : "copilot";
-        List<String> args = new ArrayList<>();
+        var args = new ArrayList<String>();
 
         if (options.getCliArgs() != null) {
             args.addAll(Arrays.asList(options.getCliArgs()));
@@ -993,7 +989,7 @@ public final class CopilotClient implements AutoCloseable {
 
         List<String> command = resolveCliCommand(cliPath, args);
 
-        ProcessBuilder pb = new ProcessBuilder(command);
+        var pb = new ProcessBuilder(command);
         pb.redirectErrorStream(false);
 
         if (options.getCwd() != null) {
@@ -1014,7 +1010,7 @@ public final class CopilotClient implements AutoCloseable {
         Process process = pb.start();
 
         // Forward stderr to logger in background
-        Thread stderrThread = new Thread(() -> {
+        var stderrThread = new Thread(() -> {
             try (BufferedReader reader = new BufferedReader(
                     new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8))) {
                 String line;
@@ -1063,7 +1059,7 @@ public final class CopilotClient implements AutoCloseable {
         boolean isJsFile = cliPath.toLowerCase().endsWith(".js");
 
         if (isJsFile) {
-            List<String> result = new ArrayList<>();
+            var result = new ArrayList<String>();
             result.add("node");
             result.add(cliPath);
             result.addAll(args);
@@ -1073,7 +1069,7 @@ public final class CopilotClient implements AutoCloseable {
         // On Windows, use cmd /c to resolve the executable
         String os = System.getProperty("os.name").toLowerCase();
         if (os.contains("win") && !new File(cliPath).isAbsolute()) {
-            List<String> result = new ArrayList<>();
+            var result = new ArrayList<String>();
             result.add("cmd");
             result.add("/c");
             result.add(cliPath);
@@ -1081,7 +1077,7 @@ public final class CopilotClient implements AutoCloseable {
             return result;
         }
 
-        List<String> result = new ArrayList<>();
+        var result = new ArrayList<String>();
         result.add(cliPath);
         result.addAll(args);
         return result;

--- a/src/main/java/com/github/copilot/sdk/CopilotSession.java
+++ b/src/main/java/com/github/copilot/sdk/CopilotSession.java
@@ -13,7 +13,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -196,7 +195,7 @@ public final class CopilotSession implements AutoCloseable {
      * @see #send(String)
      */
     public CompletableFuture<String> send(MessageOptions options) {
-        SendMessageRequest request = new SendMessageRequest();
+        var request = new SendMessageRequest();
         request.setSessionId(sessionId);
         request.setPrompt(options.getPrompt());
         request.setAttachments(options.getAttachments());
@@ -225,8 +224,8 @@ public final class CopilotSession implements AutoCloseable {
      * @see #send(MessageOptions)
      */
     public CompletableFuture<AssistantMessageEvent> sendAndWait(MessageOptions options, long timeoutMs) {
-        CompletableFuture<AssistantMessageEvent> future = new CompletableFuture<>();
-        AtomicReference<AssistantMessageEvent> lastAssistantMessage = new AtomicReference<>();
+        var future = new CompletableFuture<AssistantMessageEvent>();
+        var lastAssistantMessage = new AtomicReference<AssistantMessageEvent>();
 
         Consumer<AbstractSessionEvent> handler = evt -> {
             if (evt instanceof AssistantMessageEvent msg) {
@@ -252,8 +251,8 @@ public final class CopilotSession implements AutoCloseable {
         });
 
         // Set up timeout with daemon thread so it doesn't prevent JVM exit
-        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread t = new Thread(r, "sendAndWait-timeout");
+        var scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            var t = new Thread(r, "sendAndWait-timeout");
             t.setDaemon(true);
             return t;
         });
@@ -444,7 +443,7 @@ public final class CopilotSession implements AutoCloseable {
 
         try {
             PermissionRequest request = MAPPER.treeToValue(permissionRequestData, PermissionRequest.class);
-            PermissionInvocation invocation = new PermissionInvocation();
+            var invocation = new PermissionInvocation();
             invocation.setSessionId(sessionId);
             return handler.handle(request, invocation).exceptionally(ex -> {
                 LOG.log(Level.SEVERE, "Permission handler threw an exception", ex);
@@ -489,7 +488,7 @@ public final class CopilotSession implements AutoCloseable {
         }
 
         try {
-            UserInputInvocation invocation = new UserInputInvocation().setSessionId(sessionId);
+            var invocation = new UserInputInvocation().setSessionId(sessionId);
             return handler.handle(request, invocation).exceptionally(ex -> {
                 LOG.log(Level.SEVERE, "User input handler threw an exception", ex);
                 throw new RuntimeException("User input handler error", ex);
@@ -529,7 +528,7 @@ public final class CopilotSession implements AutoCloseable {
             return CompletableFuture.completedFuture(null);
         }
 
-        HookInvocation invocation = new HookInvocation().setSessionId(sessionId);
+        var invocation = new HookInvocation().setSessionId(sessionId);
 
         try {
             switch (hookType) {
@@ -592,7 +591,7 @@ public final class CopilotSession implements AutoCloseable {
     public CompletableFuture<List<AbstractSessionEvent>> getMessages() {
         return rpc.invoke("session.getMessages", Map.of("sessionId", sessionId), GetMessagesResponse.class)
                 .thenApply(response -> {
-                    List<AbstractSessionEvent> events = new ArrayList<>();
+                    var events = new ArrayList<AbstractSessionEvent>();
                     if (response.getEvents() != null) {
                         for (JsonNode eventNode : response.getEvents()) {
                             try {

--- a/src/main/java/com/github/copilot/sdk/JsonRpcClient.java
+++ b/src/main/java/com/github/copilot/sdk/JsonRpcClient.java
@@ -66,7 +66,7 @@ class JsonRpcClient implements AutoCloseable {
     }
 
     static ObjectMapper createObjectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
+        var mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
@@ -105,10 +105,10 @@ class JsonRpcClient implements AutoCloseable {
      */
     public <T> CompletableFuture<T> invoke(String method, Object params, Class<T> responseType) {
         long id = requestIdCounter.incrementAndGet();
-        CompletableFuture<JsonNode> future = new CompletableFuture<>();
+        var future = new CompletableFuture<JsonNode>();
         pendingRequests.put(id, future);
 
-        JsonRpcRequest request = new JsonRpcRequest();
+        var request = new JsonRpcRequest();
         request.setJsonrpc("2.0");
         request.setId(id);
         request.setMethod(method);
@@ -137,7 +137,7 @@ class JsonRpcClient implements AutoCloseable {
      * Sends a JSON-RPC notification (no response expected).
      */
     public void notify(String method, Object params) throws IOException {
-        JsonRpcRequest notification = new JsonRpcRequest();
+        var notification = new JsonRpcRequest();
         notification.setJsonrpc("2.0");
         notification.setMethod(method);
         notification.setParams(params);
@@ -148,7 +148,7 @@ class JsonRpcClient implements AutoCloseable {
      * Sends a JSON-RPC response to a server request.
      */
     public void sendResponse(Object id, Object result) throws IOException {
-        JsonRpcResponse response = new JsonRpcResponse();
+        var response = new JsonRpcResponse();
         response.setJsonrpc("2.0");
         response.setId(id);
         response.setResult(result);
@@ -159,10 +159,10 @@ class JsonRpcClient implements AutoCloseable {
      * Sends a JSON-RPC error response to a server request.
      */
     public void sendErrorResponse(Object id, int code, String message) throws IOException {
-        JsonRpcResponse response = new JsonRpcResponse();
+        var response = new JsonRpcResponse();
         response.setJsonrpc("2.0");
         response.setId(id);
-        JsonRpcError error = new JsonRpcError();
+        var error = new JsonRpcError();
         error.setCode(code);
         error.setMessage(message);
         response.setError(error);
@@ -186,12 +186,12 @@ class JsonRpcClient implements AutoCloseable {
             try {
                 // We need to read bytes because Content-Length specifies bytes, not characters.
                 // Using BufferedReader would cause issues with multi-byte UTF-8 characters.
-                BufferedInputStream bis = new BufferedInputStream(inputStream);
+                var bis = new BufferedInputStream(inputStream);
 
                 while (running) {
                     // Read headers line by line
                     int contentLength = -1;
-                    StringBuilder headerLine = new StringBuilder();
+                    var headerLine = new StringBuilder();
                     boolean lastWasCR = false;
                     boolean inHeaders = true;
 

--- a/src/test/java/com/github/copilot/sdk/AskUserTest.java
+++ b/src/test/java/com/github/copilot/sdk/AskUserTest.java
@@ -7,7 +7,6 @@ package com.github.copilot.sdk;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -54,10 +53,10 @@ public class AskUserTest {
     void testShouldInvokeUserInputHandlerWhenModelUsesAskUserTool() throws Exception {
         ctx.configureForTest("ask_user", "should_invoke_user_input_handler_when_model_uses_ask_user_tool");
 
-        List<UserInputRequest> userInputRequests = new ArrayList<>();
+        var userInputRequests = new ArrayList<UserInputRequest>();
         final String[] sessionIdHolder = new String[1];
 
-        SessionConfig config = new SessionConfig().setOnUserInputRequest((request, invocation) -> {
+        var config = new SessionConfig().setOnUserInputRequest((request, invocation) -> {
             userInputRequests.add(request);
             assertEquals(sessionIdHolder[0], invocation.getSessionId());
 
@@ -97,9 +96,9 @@ public class AskUserTest {
     void testShouldReceiveChoicesInUserInputRequest() throws Exception {
         ctx.configureForTest("ask_user", "should_receive_choices_in_user_input_request");
 
-        List<UserInputRequest> userInputRequests = new ArrayList<>();
+        var userInputRequests = new ArrayList<UserInputRequest>();
 
-        SessionConfig config = new SessionConfig().setOnUserInputRequest((request, invocation) -> {
+        var config = new SessionConfig().setOnUserInputRequest((request, invocation) -> {
             userInputRequests.add(request);
 
             // Pick the first choice
@@ -135,10 +134,10 @@ public class AskUserTest {
     void testShouldHandleFreeformUserInputResponse() throws Exception {
         ctx.configureForTest("ask_user", "should_handle_freeform_user_input_response");
 
-        final List<UserInputRequest> userInputRequests = new ArrayList<>();
+        final var userInputRequests = new ArrayList<UserInputRequest>();
         String freeformAnswer = "This is my custom freeform answer that was not in the choices";
 
-        SessionConfig config = new SessionConfig().setOnUserInputRequest((request, invocation) -> {
+        var config = new SessionConfig().setOnUserInputRequest((request, invocation) -> {
             userInputRequests.add(request);
 
             // Return a freeform answer (not from choices)

--- a/src/test/java/com/github/copilot/sdk/CapiProxy.java
+++ b/src/test/java/com/github/copilot/sdk/CapiProxy.java
@@ -89,7 +89,7 @@ public class CapiProxy implements AutoCloseable {
         }
 
         // Start the harness server using npx tsx
-        ProcessBuilder pb = new ProcessBuilder("npx", "tsx", "server.ts");
+        var pb = new ProcessBuilder("npx", "tsx", "server.ts");
         pb.directory(harnessDir.toFile());
         pb.redirectErrorStream(false);
 

--- a/src/test/java/com/github/copilot/sdk/CompactionTest.java
+++ b/src/test/java/com/github/copilot/sdk/CompactionTest.java
@@ -7,7 +7,6 @@ package com.github.copilot.sdk;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterAll;
@@ -61,15 +60,15 @@ public class CompactionTest {
 
         // Create session with very low compaction thresholds to trigger compaction
         // quickly
-        InfiniteSessionConfig infiniteConfig = new InfiniteSessionConfig().setEnabled(true)
+        var infiniteConfig = new InfiniteSessionConfig().setEnabled(true)
                 // Trigger background compaction at 0.5% context usage (~1000 tokens)
                 .setBackgroundCompactionThreshold(0.005)
                 // Block at 1% to ensure compaction runs
                 .setBufferExhaustionThreshold(0.01);
 
-        SessionConfig config = new SessionConfig().setInfiniteSessions(infiniteConfig);
+        var config = new SessionConfig().setInfiniteSessions(infiniteConfig);
 
-        List<AbstractSessionEvent> events = new ArrayList<>();
+        var events = new ArrayList<AbstractSessionEvent>();
 
         try (CopilotClient client = ctx.createClient()) {
             CopilotSession session = client.createSession(config).get();
@@ -131,11 +130,11 @@ public class CompactionTest {
     void testShouldNotEmitCompactionEventsWhenInfiniteSessionsDisabled() throws Exception {
         ctx.configureForTest("compaction", "should_not_emit_compaction_events_when_infinite_sessions_disabled");
 
-        InfiniteSessionConfig infiniteConfig = new InfiniteSessionConfig().setEnabled(false);
+        var infiniteConfig = new InfiniteSessionConfig().setEnabled(false);
 
-        SessionConfig config = new SessionConfig().setInfiniteSessions(infiniteConfig);
+        var config = new SessionConfig().setInfiniteSessions(infiniteConfig);
 
-        List<AbstractSessionEvent> compactionEvents = new ArrayList<>();
+        var compactionEvents = new ArrayList<AbstractSessionEvent>();
 
         try (CopilotClient client = ctx.createClient()) {
             CopilotSession session = client.createSession(config).get();

--- a/src/test/java/com/github/copilot/sdk/CopilotClientTest.java
+++ b/src/test/java/com/github/copilot/sdk/CopilotClientTest.java
@@ -63,7 +63,7 @@ public class CopilotClientTest {
         try {
             // Use 'where' on Windows, 'which' on Unix-like systems
             String command = System.getProperty("os.name").toLowerCase().contains("win") ? "where" : "which";
-            ProcessBuilder pb = new ProcessBuilder(command, "copilot");
+            var pb = new ProcessBuilder(command, "copilot");
             pb.redirectErrorStream(true);
             Process process = pb.start();
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
@@ -81,31 +81,30 @@ public class CopilotClientTest {
 
     @Test
     void testClientConstruction() {
-        CopilotClient client = new CopilotClient();
+        var client = new CopilotClient();
         assertEquals(ConnectionState.DISCONNECTED, client.getState());
         client.close();
     }
 
     @Test
     void testClientConstructionWithOptions() {
-        CopilotClientOptions options = new CopilotClientOptions().setCliPath("/path/to/cli").setLogLevel("debug")
-                .setAutoStart(false);
+        var options = new CopilotClientOptions().setCliPath("/path/to/cli").setLogLevel("debug").setAutoStart(false);
 
-        CopilotClient client = new CopilotClient(options);
+        var client = new CopilotClient(options);
         assertEquals(ConnectionState.DISCONNECTED, client.getState());
         client.close();
     }
 
     @Test
     void testCliUrlMutualExclusion() {
-        CopilotClientOptions options = new CopilotClientOptions().setCliUrl("localhost:3000").setUseStdio(true);
+        var options = new CopilotClientOptions().setCliUrl("localhost:3000").setUseStdio(true);
 
         assertThrows(IllegalArgumentException.class, () -> new CopilotClient(options));
     }
 
     @Test
     void testCliUrlMutualExclusionWithCliPath() {
-        CopilotClientOptions options = new CopilotClientOptions().setCliUrl("localhost:3000").setCliPath("/path/to/cli")
+        var options = new CopilotClientOptions().setCliUrl("localhost:3000").setCliPath("/path/to/cli")
                 .setUseStdio(false);
 
         assertThrows(IllegalArgumentException.class, () -> new CopilotClient(options));
@@ -166,45 +165,44 @@ public class CopilotClientTest {
 
     @Test
     void testGithubTokenOptionAccepted() {
-        CopilotClientOptions options = new CopilotClientOptions().setCliPath("/path/to/cli")
-                .setGithubToken("gho_test_token");
+        var options = new CopilotClientOptions().setCliPath("/path/to/cli").setGithubToken("gho_test_token");
 
         assertEquals("gho_test_token", options.getGithubToken());
     }
 
     @Test
     void testUseLoggedInUserDefaultsToNull() {
-        CopilotClientOptions options = new CopilotClientOptions().setCliPath("/path/to/cli");
+        var options = new CopilotClientOptions().setCliPath("/path/to/cli");
 
         assertNull(options.getUseLoggedInUser());
     }
 
     @Test
     void testExplicitUseLoggedInUserFalse() {
-        CopilotClientOptions options = new CopilotClientOptions().setCliPath("/path/to/cli").setUseLoggedInUser(false);
+        var options = new CopilotClientOptions().setCliPath("/path/to/cli").setUseLoggedInUser(false);
 
         assertEquals(false, options.getUseLoggedInUser());
     }
 
     @Test
     void testExplicitUseLoggedInUserTrueWithGithubToken() {
-        CopilotClientOptions options = new CopilotClientOptions().setCliPath("/path/to/cli")
-                .setGithubToken("gho_test_token").setUseLoggedInUser(true);
+        var options = new CopilotClientOptions().setCliPath("/path/to/cli").setGithubToken("gho_test_token")
+                .setUseLoggedInUser(true);
 
         assertEquals(true, options.getUseLoggedInUser());
     }
 
     @Test
     void testGithubTokenWithCliUrlThrows() {
-        CopilotClientOptions options = new CopilotClientOptions().setCliUrl("localhost:8080")
-                .setGithubToken("gho_test_token").setUseStdio(false);
+        var options = new CopilotClientOptions().setCliUrl("localhost:8080").setGithubToken("gho_test_token")
+                .setUseStdio(false);
 
         assertThrows(IllegalArgumentException.class, () -> new CopilotClient(options));
     }
 
     @Test
     void testUseLoggedInUserWithCliUrlThrows() {
-        CopilotClientOptions options = new CopilotClientOptions().setCliUrl("localhost:8080").setUseLoggedInUser(false)
+        var options = new CopilotClientOptions().setCliUrl("localhost:8080").setUseLoggedInUser(false)
                 .setUseStdio(false);
 
         assertThrows(IllegalArgumentException.class, () -> new CopilotClient(options));

--- a/src/test/java/com/github/copilot/sdk/CopilotSessionTest.java
+++ b/src/test/java/com/github/copilot/sdk/CopilotSessionTest.java
@@ -178,9 +178,9 @@ public class CopilotSessionTest {
         try (CopilotClient client = ctx.createClient()) {
             CopilotSession session = client.createSession().get();
 
-            List<String> events = new ArrayList<>();
-            AtomicReference<AssistantMessageEvent> lastMessage = new AtomicReference<>();
-            CompletableFuture<Void> done = new CompletableFuture<>();
+            var events = new ArrayList<String>();
+            var lastMessage = new AtomicReference<AssistantMessageEvent>();
+            var done = new CompletableFuture<Void>();
 
             session.on(evt -> {
                 events.add(evt.getType());
@@ -224,7 +224,7 @@ public class CopilotSessionTest {
         try (CopilotClient client = ctx.createClient()) {
             CopilotSession session = client.createSession().get();
 
-            List<String> events = new ArrayList<>();
+            var events = new ArrayList<String>();
             session.on(evt -> events.add(evt.getType()));
 
             AssistantMessageEvent response = session.sendAndWait(new MessageOptions().setPrompt("What is 2+2?")).get(60,
@@ -391,8 +391,8 @@ public class CopilotSessionTest {
 
             CopilotSession session = client.createSession(config).get();
 
-            List<AbstractSessionEvent> receivedEvents = new ArrayList<>();
-            CompletableFuture<Void> idleReceived = new CompletableFuture<>();
+            var receivedEvents = new ArrayList<AbstractSessionEvent>();
+            var idleReceived = new CompletableFuture<Void>();
 
             session.on(evt -> {
                 receivedEvents.add(evt);
@@ -427,8 +427,8 @@ public class CopilotSessionTest {
             assertNotNull(session.getSessionId());
 
             // Set up wait for tool execution to start BEFORE sending
-            CompletableFuture<ToolExecutionStartEvent> toolStartFuture = new CompletableFuture<>();
-            CompletableFuture<SessionIdleEvent> sessionIdleFuture = new CompletableFuture<>();
+            var toolStartFuture = new CompletableFuture<ToolExecutionStartEvent>();
+            var sessionIdleFuture = new CompletableFuture<SessionIdleEvent>();
 
             session.on(evt -> {
                 if (evt instanceof ToolExecutionStartEvent toolStart && !toolStartFuture.isDone()) {

--- a/src/test/java/com/github/copilot/sdk/ErrorHandlingTest.java
+++ b/src/test/java/com/github/copilot/sdk/ErrorHandlingTest.java
@@ -59,7 +59,7 @@ public class ErrorHandlingTest {
         LOG.info("Running test: testHandlesToolCallingErrors_toolErrorDoesNotCrashSession");
         ctx.configureForTest("tools", "handles_tool_calling_errors");
 
-        List<AbstractSessionEvent> allEvents = new ArrayList<>();
+        var allEvents = new ArrayList<AbstractSessionEvent>();
 
         ToolDefinition errorTool = ToolDefinition.create("get_user_location", "Gets the user's location",
                 Map.of("type", "object", "properties", Map.of()), (invocation) -> {
@@ -130,9 +130,9 @@ public class ErrorHandlingTest {
         LOG.info("Running test: testShouldHandlePermissionHandlerErrorsGracefully_deniesPermission");
         ctx.configureForTest("permissions", "should_handle_permission_handler_errors_gracefully");
 
-        List<SessionErrorEvent> errorEvents = new ArrayList<>();
+        var errorEvents = new ArrayList<SessionErrorEvent>();
 
-        SessionConfig config = new SessionConfig().setOnPermissionRequest((request, invocation) -> {
+        var config = new SessionConfig().setOnPermissionRequest((request, invocation) -> {
             throw new RuntimeException("Permission handler crashed");
         });
 
@@ -169,9 +169,9 @@ public class ErrorHandlingTest {
         LOG.info("Running test: testPermissionHandlerErrors_sessionErrorEventContainsDetails");
         ctx.configureForTest("permissions", "permission_handler_errors");
 
-        List<SessionErrorEvent> errorEvents = new ArrayList<>();
+        var errorEvents = new ArrayList<SessionErrorEvent>();
 
-        SessionConfig config = new SessionConfig().setOnPermissionRequest((request, invocation) -> {
+        var config = new SessionConfig().setOnPermissionRequest((request, invocation) -> {
             throw new RuntimeException("Test error message");
         });
 

--- a/src/test/java/com/github/copilot/sdk/HooksTest.java
+++ b/src/test/java/com/github/copilot/sdk/HooksTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -65,10 +64,10 @@ public class HooksTest {
     void testInvokePreToolUseHookWhenModelRunsATool() throws Exception {
         ctx.configureForTest("hooks", "invoke_pre_tool_use_hook_when_model_runs_a_tool");
 
-        List<PreToolUseHookInput> preToolUseInputs = new ArrayList<>();
+        var preToolUseInputs = new ArrayList<PreToolUseHookInput>();
         final String[] sessionIdHolder = new String[1];
 
-        SessionConfig config = new SessionConfig().setHooks(new SessionHooks().setOnPreToolUse((input, invocation) -> {
+        var config = new SessionConfig().setHooks(new SessionHooks().setOnPreToolUse((input, invocation) -> {
             preToolUseInputs.add(input);
             assertEquals(sessionIdHolder[0], invocation.getSessionId());
             return CompletableFuture.completedFuture(new PreToolUseHookOutput().setPermissionDecision("allow"));
@@ -104,10 +103,10 @@ public class HooksTest {
     void testInvokePostToolUseHookAfterModelRunsATool() throws Exception {
         ctx.configureForTest("hooks", "invoke_post_tool_use_hook_after_model_runs_a_tool");
 
-        List<PostToolUseHookInput> postToolUseInputs = new ArrayList<>();
+        var postToolUseInputs = new ArrayList<PostToolUseHookInput>();
         final String[] sessionIdHolder = new String[1];
 
-        SessionConfig config = new SessionConfig().setHooks(new SessionHooks().setOnPostToolUse((input, invocation) -> {
+        var config = new SessionConfig().setHooks(new SessionHooks().setOnPostToolUse((input, invocation) -> {
             postToolUseInputs.add(input);
             assertEquals(sessionIdHolder[0], invocation.getSessionId());
             return CompletableFuture.completedFuture(null);
@@ -145,10 +144,10 @@ public class HooksTest {
     void testInvokeBothHooksForSingleToolCall() throws Exception {
         ctx.configureForTest("hooks", "invoke_both_hooks_for_single_tool_call");
 
-        List<PreToolUseHookInput> preToolUseInputs = new ArrayList<>();
-        List<PostToolUseHookInput> postToolUseInputs = new ArrayList<>();
+        var preToolUseInputs = new ArrayList<PreToolUseHookInput>();
+        var postToolUseInputs = new ArrayList<PostToolUseHookInput>();
 
-        SessionConfig config = new SessionConfig().setHooks(new SessionHooks().setOnPreToolUse((input, invocation) -> {
+        var config = new SessionConfig().setHooks(new SessionHooks().setOnPreToolUse((input, invocation) -> {
             preToolUseInputs.add(input);
             return CompletableFuture.completedFuture(new PreToolUseHookOutput().setPermissionDecision("allow"));
         }).setOnPostToolUse((input, invocation) -> {
@@ -191,9 +190,9 @@ public class HooksTest {
     void testDenyToolExecutionWhenPreToolUseReturnsDeny() throws Exception {
         ctx.configureForTest("hooks", "deny_tool_execution_when_pre_tool_use_returns_deny");
 
-        List<PreToolUseHookInput> preToolUseInputs = new ArrayList<>();
+        var preToolUseInputs = new ArrayList<PreToolUseHookInput>();
 
-        SessionConfig config = new SessionConfig().setHooks(new SessionHooks().setOnPreToolUse((input, invocation) -> {
+        var config = new SessionConfig().setHooks(new SessionHooks().setOnPreToolUse((input, invocation) -> {
             preToolUseInputs.add(input);
             // Deny all tool calls
             return CompletableFuture.completedFuture(new PreToolUseHookOutput().setPermissionDecision("deny"));

--- a/src/test/java/com/github/copilot/sdk/McpAndAgentsTest.java
+++ b/src/test/java/com/github/copilot/sdk/McpAndAgentsTest.java
@@ -47,7 +47,7 @@ public class McpAndAgentsTest {
 
     // Helper method to create an MCP local server configuration
     private Map<String, Object> createLocalMcpServer(String command, List<String> args) {
-        Map<String, Object> server = new HashMap<>();
+        var server = new HashMap<String, Object>();
         server.put("type", "local");
         server.put("command", command);
         server.put("args", args);
@@ -67,7 +67,7 @@ public class McpAndAgentsTest {
     void testShouldAcceptMcpServerConfigurationOnSessionCreate() throws Exception {
         ctx.configureForTest("mcp_and_agents", "should_accept_mcp_server_configuration_on_session_create");
 
-        Map<String, Object> mcpServers = new HashMap<>();
+        var mcpServers = new HashMap<String, Object>();
         mcpServers.put("test-server", createLocalMcpServer("echo", List.of("hello")));
 
         try (CopilotClient client = ctx.createClient()) {
@@ -104,7 +104,7 @@ public class McpAndAgentsTest {
             session1.sendAndWait(new MessageOptions().setPrompt("What is 1+1?")).get(60, TimeUnit.SECONDS);
 
             // Resume with MCP servers
-            Map<String, Object> mcpServers = new HashMap<>();
+            var mcpServers = new HashMap<String, Object>();
             mcpServers.put("test-server", createLocalMcpServer("echo", List.of("hello")));
 
             CopilotSession session2 = client
@@ -135,7 +135,7 @@ public class McpAndAgentsTest {
         // count
         ctx.configureForTest("mcp_and_agents", "should_accept_mcp_server_configuration_on_session_create");
 
-        Map<String, Object> mcpServers = new HashMap<>();
+        var mcpServers = new HashMap<String, Object>();
         mcpServers.put("server1", createLocalMcpServer("echo", List.of("server1")));
         mcpServers.put("server2", createLocalMcpServer("echo", List.of("server2")));
 
@@ -252,7 +252,7 @@ public class McpAndAgentsTest {
         // Use combined snapshot since this uses both MCP servers and custom agents
         ctx.configureForTest("mcp_and_agents", "should_accept_both_mcp_servers_and_custom_agents");
 
-        Map<String, Object> agentMcpServers = new HashMap<>();
+        var agentMcpServers = new HashMap<String, Object>();
         agentMcpServers.put("agent-server", createLocalMcpServer("echo", List.of("agent-mcp")));
 
         List<CustomAgentConfig> customAgents = List.of(new CustomAgentConfig().setName("mcp-agent")
@@ -304,7 +304,7 @@ public class McpAndAgentsTest {
     void testShouldAcceptBothMcpServersAndCustomAgents() throws Exception {
         ctx.configureForTest("mcp_and_agents", "should_accept_both_mcp_servers_and_custom_agents");
 
-        Map<String, Object> mcpServers = new HashMap<>();
+        var mcpServers = new HashMap<String, Object>();
         mcpServers.put("shared-server", createLocalMcpServer("echo", List.of("shared")));
 
         List<CustomAgentConfig> customAgents = List.of(new CustomAgentConfig().setName("combined-agent")

--- a/src/test/java/com/github/copilot/sdk/MetadataApiTest.java
+++ b/src/test/java/com/github/copilot/sdk/MetadataApiTest.java
@@ -62,7 +62,7 @@ public class MetadataApiTest {
     private static String findCopilotInPath() {
         try {
             String command = System.getProperty("os.name").toLowerCase().contains("win") ? "where" : "which";
-            ProcessBuilder pb = new ProcessBuilder(command, "copilot");
+            var pb = new ProcessBuilder(command, "copilot");
             pb.redirectErrorStream(true);
             Process process = pb.start();
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {

--- a/src/test/java/com/github/copilot/sdk/PermissionsTest.java
+++ b/src/test/java/com/github/copilot/sdk/PermissionsTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -58,11 +57,11 @@ public class PermissionsTest {
     void testPermissionHandlerForWriteOperations(TestInfo testInfo) throws Exception {
         ctx.configureForTest("permissions", "permission_handler_for_write_operations");
 
-        List<PermissionRequest> permissionRequests = new ArrayList<>();
+        var permissionRequests = new ArrayList<PermissionRequest>();
 
         final String[] sessionIdHolder = new String[1];
 
-        SessionConfig config = new SessionConfig().setOnPermissionRequest((request, invocation) -> {
+        var config = new SessionConfig().setOnPermissionRequest((request, invocation) -> {
             permissionRequests.add(request);
             assertEquals(sessionIdHolder[0], invocation.getSessionId());
             // Approve the permission
@@ -100,7 +99,7 @@ public class PermissionsTest {
     void testDenyPermission(TestInfo testInfo) throws Exception {
         ctx.configureForTest("permissions", "deny_permission");
 
-        SessionConfig config = new SessionConfig().setOnPermissionRequest((request, invocation) -> {
+        var config = new SessionConfig().setOnPermissionRequest((request, invocation) -> {
             // Deny all permissions
             return CompletableFuture
                     .completedFuture(new PermissionRequestResult().setKind("denied-interactively-by-user"));
@@ -158,9 +157,9 @@ public class PermissionsTest {
     void testAsyncPermissionHandler(TestInfo testInfo) throws Exception {
         ctx.configureForTest("permissions", "async_permission_handler");
 
-        List<PermissionRequest> permissionRequests = new ArrayList<>();
+        var permissionRequests = new ArrayList<PermissionRequest>();
 
-        SessionConfig config = new SessionConfig().setOnPermissionRequest((request, invocation) -> {
+        var config = new SessionConfig().setOnPermissionRequest((request, invocation) -> {
             permissionRequests.add(request);
 
             // Simulate async permission check with delay
@@ -196,7 +195,7 @@ public class PermissionsTest {
     void testResumeSessionWithPermissionHandler(TestInfo testInfo) throws Exception {
         ctx.configureForTest("permissions", "resume_session_with_permission_handler");
 
-        List<PermissionRequest> permissionRequests = new ArrayList<>();
+        var permissionRequests = new ArrayList<PermissionRequest>();
 
         try (CopilotClient client = ctx.createClient()) {
             // Create session without permission handler
@@ -205,11 +204,10 @@ public class PermissionsTest {
             session1.sendAndWait(new MessageOptions().setPrompt("What is 1+1?")).get(60, TimeUnit.SECONDS);
 
             // Resume with permission handler
-            ResumeSessionConfig resumeConfig = new ResumeSessionConfig()
-                    .setOnPermissionRequest((request, invocation) -> {
-                        permissionRequests.add(request);
-                        return CompletableFuture.completedFuture(new PermissionRequestResult().setKind("approved"));
-                    });
+            var resumeConfig = new ResumeSessionConfig().setOnPermissionRequest((request, invocation) -> {
+                permissionRequests.add(request);
+                return CompletableFuture.completedFuture(new PermissionRequestResult().setKind("approved"));
+            });
 
             CopilotSession session2 = client.resumeSession(sessionId, resumeConfig).get();
 
@@ -235,7 +233,7 @@ public class PermissionsTest {
 
         final boolean[] receivedToolCallId = {false};
 
-        SessionConfig config = new SessionConfig().setOnPermissionRequest((request, invocation) -> {
+        var config = new SessionConfig().setOnPermissionRequest((request, invocation) -> {
             if (request.getToolCallId() != null) {
                 receivedToolCallId[0] = true;
                 assertFalse(request.getToolCallId().isEmpty(), "Tool call ID should not be empty");
@@ -267,7 +265,7 @@ public class PermissionsTest {
     void testShouldHandlePermissionHandlerErrorsGracefully(TestInfo testInfo) throws Exception {
         ctx.configureForTest("permissions", "should_handle_permission_handler_errors_gracefully");
 
-        SessionConfig config = new SessionConfig().setOnPermissionRequest((request, invocation) -> {
+        var config = new SessionConfig().setOnPermissionRequest((request, invocation) -> {
             // Throw an error in the handler
             throw new RuntimeException("Handler error");
         });

--- a/src/test/java/com/github/copilot/sdk/SessionEventHandlingTest.java
+++ b/src/test/java/com/github/copilot/sdk/SessionEventHandlingTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.Closeable;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
@@ -49,7 +48,7 @@ public class SessionEventHandlingTest {
 
     @Test
     void testGenericEventHandler() {
-        List<AbstractSessionEvent> receivedEvents = new ArrayList<>();
+        var receivedEvents = new ArrayList<AbstractSessionEvent>();
 
         session.on(event -> receivedEvents.add(event));
 
@@ -66,7 +65,7 @@ public class SessionEventHandlingTest {
 
     @Test
     void testTypedEventHandler() {
-        List<AssistantMessageEvent> receivedMessages = new ArrayList<>();
+        var receivedMessages = new ArrayList<AssistantMessageEvent>();
 
         session.on(AssistantMessageEvent.class, msg -> receivedMessages.add(msg));
 
@@ -84,9 +83,9 @@ public class SessionEventHandlingTest {
 
     @Test
     void testMultipleTypedHandlers() {
-        List<AssistantMessageEvent> messages = new ArrayList<>();
-        List<SessionIdleEvent> idles = new ArrayList<>();
-        List<SessionStartEvent> starts = new ArrayList<>();
+        var messages = new ArrayList<AssistantMessageEvent>();
+        var idles = new ArrayList<SessionIdleEvent>();
+        var starts = new ArrayList<SessionStartEvent>();
 
         session.on(AssistantMessageEvent.class, messages::add);
         session.on(SessionIdleEvent.class, idles::add);
@@ -104,7 +103,7 @@ public class SessionEventHandlingTest {
 
     @Test
     void testUnsubscribe() {
-        AtomicInteger count = new AtomicInteger(0);
+        var count = new AtomicInteger(0);
 
         Closeable subscription = session.on(AssistantMessageEvent.class, msg -> count.incrementAndGet());
 
@@ -125,7 +124,7 @@ public class SessionEventHandlingTest {
 
     @Test
     void testUnsubscribeGenericHandler() {
-        AtomicInteger count = new AtomicInteger(0);
+        var count = new AtomicInteger(0);
 
         Closeable subscription = session.on(event -> count.incrementAndGet());
 
@@ -144,8 +143,8 @@ public class SessionEventHandlingTest {
 
     @Test
     void testMixedHandlers() {
-        List<String> allEvents = new ArrayList<>();
-        List<String> messageEvents = new ArrayList<>();
+        var allEvents = new ArrayList<String>();
+        var messageEvents = new ArrayList<String>();
 
         // Generic handler captures everything
         session.on(event -> allEvents.add(event.getType()));
@@ -164,8 +163,8 @@ public class SessionEventHandlingTest {
 
     @Test
     void testHandlerReceivesCorrectEventData() {
-        AtomicReference<String> capturedContent = new AtomicReference<>();
-        AtomicReference<String> capturedSessionId = new AtomicReference<>();
+        var capturedContent = new AtomicReference<String>();
+        var capturedSessionId = new AtomicReference<String>();
 
         session.on(AssistantMessageEvent.class, msg -> {
             capturedContent.set(msg.getData().getContent());
@@ -188,7 +187,7 @@ public class SessionEventHandlingTest {
 
     @Test
     void testHandlerExceptionDoesNotBreakOtherHandlers() {
-        List<String> handler2Events = new ArrayList<>();
+        var handler2Events = new ArrayList<String>();
 
         // Suppress logging for this test to avoid confusing stack traces in build
         // output
@@ -241,16 +240,16 @@ public class SessionEventHandlingTest {
 
     // Factory methods for creating test events
     private SessionStartEvent createSessionStartEvent() {
-        SessionStartEvent event = new SessionStartEvent();
-        SessionStartEvent.SessionStartData data = new SessionStartEvent.SessionStartData();
+        var event = new SessionStartEvent();
+        var data = new SessionStartEvent.SessionStartData();
         data.setSessionId("test-session");
         event.setData(data);
         return event;
     }
 
     private AssistantMessageEvent createAssistantMessageEvent(String content) {
-        AssistantMessageEvent event = new AssistantMessageEvent();
-        AssistantMessageEvent.AssistantMessageData data = new AssistantMessageEvent.AssistantMessageData();
+        var event = new AssistantMessageEvent();
+        var data = new AssistantMessageEvent.AssistantMessageData();
         data.setContent(content);
         event.setData(data);
         return event;

--- a/src/test/java/com/github/copilot/sdk/SessionEventParserTest.java
+++ b/src/test/java/com/github/copilot/sdk/SessionEventParserTest.java
@@ -43,7 +43,7 @@ public class SessionEventParserTest {
         assertInstanceOf(SessionStartEvent.class, event);
         assertEquals("session.start", event.getType());
 
-        SessionStartEvent startEvent = (SessionStartEvent) event;
+        var startEvent = (SessionStartEvent) event;
         assertEquals("sess-123", startEvent.getData().getSessionId());
     }
 
@@ -82,7 +82,7 @@ public class SessionEventParserTest {
         assertInstanceOf(SessionErrorEvent.class, event);
         assertEquals("session.error", event.getType());
 
-        SessionErrorEvent errorEvent = (SessionErrorEvent) event;
+        var errorEvent = (SessionErrorEvent) event;
         assertEquals("RateLimitError", errorEvent.getData().getErrorType());
         assertEquals("Rate limit exceeded", errorEvent.getData().getMessage());
         assertNotNull(errorEvent.getData().getStack());
@@ -120,7 +120,7 @@ public class SessionEventParserTest {
         assertInstanceOf(SessionInfoEvent.class, event);
         assertEquals("session.info", event.getType());
 
-        SessionInfoEvent infoEvent = (SessionInfoEvent) event;
+        var infoEvent = (SessionInfoEvent) event;
         assertEquals("status", infoEvent.getData().getInfoType());
         assertEquals("Processing request", infoEvent.getData().getMessage());
     }
@@ -300,7 +300,7 @@ public class SessionEventParserTest {
         assertInstanceOf(AssistantTurnStartEvent.class, event);
         assertEquals("assistant.turn_start", event.getType());
 
-        AssistantTurnStartEvent turnEvent = (AssistantTurnStartEvent) event;
+        var turnEvent = (AssistantTurnStartEvent) event;
         assertEquals("turn-123", turnEvent.getData().getTurnId());
     }
 
@@ -338,7 +338,7 @@ public class SessionEventParserTest {
         assertInstanceOf(AssistantReasoningEvent.class, event);
         assertEquals("assistant.reasoning", event.getType());
 
-        AssistantReasoningEvent reasoningEvent = (AssistantReasoningEvent) event;
+        var reasoningEvent = (AssistantReasoningEvent) event;
         assertEquals("reason-123", reasoningEvent.getData().getReasoningId());
         assertEquals("Analyzing the code structure...", reasoningEvent.getData().getContent());
     }
@@ -378,7 +378,7 @@ public class SessionEventParserTest {
         assertInstanceOf(AssistantMessageEvent.class, event);
         assertEquals("assistant.message", event.getType());
 
-        AssistantMessageEvent msgEvent = (AssistantMessageEvent) event;
+        var msgEvent = (AssistantMessageEvent) event;
         assertEquals("Here is the code you requested.", msgEvent.getData().getContent());
     }
 
@@ -533,7 +533,7 @@ public class SessionEventParserTest {
         assertInstanceOf(ToolExecutionCompleteEvent.class, event);
         assertEquals("tool.execution_complete", event.getType());
 
-        ToolExecutionCompleteEvent completeEvent = (ToolExecutionCompleteEvent) event;
+        var completeEvent = (ToolExecutionCompleteEvent) event;
         assertTrue(completeEvent.getData().isSuccess());
     }
 
@@ -560,7 +560,7 @@ public class SessionEventParserTest {
         assertInstanceOf(SubagentStartedEvent.class, event);
         assertEquals("subagent.started", event.getType());
 
-        SubagentStartedEvent startedEvent = (SubagentStartedEvent) event;
+        var startedEvent = (SubagentStartedEvent) event;
         assertEquals("code-review", startedEvent.getData().getAgentName());
         assertEquals("Code Review Agent", startedEvent.getData().getAgentDisplayName());
     }
@@ -640,7 +640,7 @@ public class SessionEventParserTest {
         assertInstanceOf(HookStartEvent.class, event);
         assertEquals("hook.start", event.getType());
 
-        HookStartEvent hookEvent = (HookStartEvent) event;
+        var hookEvent = (HookStartEvent) event;
         assertEquals("hook-123", hookEvent.getData().getHookInvocationId());
         assertEquals("preToolUse", hookEvent.getData().getHookType());
     }
@@ -727,7 +727,7 @@ public class SessionEventParserTest {
         assertInstanceOf(SessionShutdownEvent.class, event);
         assertEquals("session.shutdown", event.getType());
 
-        SessionShutdownEvent shutdownEvent = (SessionShutdownEvent) event;
+        var shutdownEvent = (SessionShutdownEvent) event;
         assertEquals(SessionShutdownEvent.ShutdownType.ROUTINE, shutdownEvent.getData().getShutdownType());
         assertEquals(5, shutdownEvent.getData().getTotalPremiumRequests());
         assertEquals("gpt-4", shutdownEvent.getData().getCurrentModel());
@@ -754,7 +754,7 @@ public class SessionEventParserTest {
         assertInstanceOf(SkillInvokedEvent.class, event);
         assertEquals("skill.invoked", event.getType());
 
-        SkillInvokedEvent skillEvent = (SkillInvokedEvent) event;
+        var skillEvent = (SkillInvokedEvent) event;
         assertEquals("code-review", skillEvent.getData().getName());
         assertEquals("/path/to/skill", skillEvent.getData().getPath());
         assertEquals("Skill instructions here", skillEvent.getData().getContent());

--- a/src/test/java/com/github/copilot/sdk/SessionEventsE2ETest.java
+++ b/src/test/java/com/github/copilot/sdk/SessionEventsE2ETest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterAll;
@@ -61,7 +60,7 @@ public class SessionEventsE2ETest {
         // Use existing session snapshot that emits turn events
         ctx.configureForTest("session", "should_receive_session_events");
 
-        List<AbstractSessionEvent> allEvents = new ArrayList<>();
+        var allEvents = new ArrayList<AbstractSessionEvent>();
 
         try (CopilotClient client = ctx.createClient()) {
             CopilotSession session = client.createSession().get();
@@ -102,7 +101,7 @@ public class SessionEventsE2ETest {
         // Use existing session snapshot
         ctx.configureForTest("session", "should_receive_session_events");
 
-        List<UserMessageEvent> userMessages = new ArrayList<>();
+        var userMessages = new ArrayList<UserMessageEvent>();
 
         try (CopilotClient client = ctx.createClient()) {
             CopilotSession session = client.createSession().get();
@@ -127,8 +126,8 @@ public class SessionEventsE2ETest {
         // Use existing tools snapshot for built-in tool invocation
         ctx.configureForTest("tools", "invokes_built_in_tools");
 
-        List<ToolExecutionStartEvent> toolStarts = new ArrayList<>();
-        List<ToolExecutionCompleteEvent> toolCompletes = new ArrayList<>();
+        var toolStarts = new ArrayList<ToolExecutionStartEvent>();
+        var toolCompletes = new ArrayList<ToolExecutionCompleteEvent>();
 
         try (CopilotClient client = ctx.createClient()) {
             CopilotSession session = client.createSession().get();
@@ -166,7 +165,7 @@ public class SessionEventsE2ETest {
         // Use existing session snapshot
         ctx.configureForTest("session", "should_receive_session_events");
 
-        List<AssistantUsageEvent> usageEvents = new ArrayList<>();
+        var usageEvents = new ArrayList<AssistantUsageEvent>();
 
         try (CopilotClient client = ctx.createClient()) {
             CopilotSession session = client.createSession().get();
@@ -192,7 +191,7 @@ public class SessionEventsE2ETest {
         // Use existing session snapshot
         ctx.configureForTest("session", "should_receive_session_events");
 
-        List<AbstractSessionEvent> allEvents = new ArrayList<>();
+        var allEvents = new ArrayList<AbstractSessionEvent>();
 
         try (CopilotClient client = ctx.createClient()) {
             CopilotSession session = client.createSession().get();
@@ -233,7 +232,7 @@ public class SessionEventsE2ETest {
         // Use existing tools snapshot for built-in tool invocation
         ctx.configureForTest("tools", "invokes_built_in_tools");
 
-        List<String> eventTypes = new ArrayList<>();
+        var eventTypes = new ArrayList<String>();
 
         try (CopilotClient client = ctx.createClient()) {
             CopilotSession session = client.createSession().get();

--- a/src/test/java/com/github/copilot/sdk/ToolsTest.java
+++ b/src/test/java/com/github/copilot/sdk/ToolsTest.java
@@ -87,9 +87,9 @@ public class ToolsTest {
         ctx.configureForTest("tools", "invokes_custom_tool");
 
         // Define a simple encrypt_string tool
-        Map<String, Object> parameters = new HashMap<>();
-        Map<String, Object> properties = new HashMap<>();
-        Map<String, Object> inputProp = new HashMap<>();
+        var parameters = new HashMap<String, Object>();
+        var properties = new HashMap<String, Object>();
+        var inputProp = new HashMap<String, Object>();
         inputProp.put("type", "string");
         inputProp.put("description", "String to encrypt");
         properties.put("input", inputProp);
@@ -129,7 +129,7 @@ public class ToolsTest {
         ctx.configureForTest("tools", "handles_tool_calling_errors");
 
         // Define a tool that throws an error
-        Map<String, Object> parameters = new HashMap<>();
+        var parameters = new HashMap<String, Object>();
         parameters.put("type", "object");
         parameters.put("properties", new HashMap<>());
 
@@ -169,8 +169,8 @@ public class ToolsTest {
         ctx.configureForTest("tools", "can_receive_and_return_complex_types");
 
         // Define a db_query tool with complex parameter and return types
-        Map<String, Object> querySchema = new HashMap<>();
-        Map<String, Object> queryProps = new HashMap<>();
+        var querySchema = new HashMap<String, Object>();
+        var queryProps = new HashMap<String, Object>();
         queryProps.put("table", Map.of("type", "string"));
         queryProps.put("ids", Map.of("type", "array", "items", Map.of("type", "integer")));
         queryProps.put("sortAscending", Map.of("type", "boolean"));
@@ -178,8 +178,8 @@ public class ToolsTest {
         querySchema.put("properties", queryProps);
         querySchema.put("required", List.of("table", "ids", "sortAscending"));
 
-        Map<String, Object> parameters = new HashMap<>();
-        Map<String, Object> properties = new HashMap<>();
+        var parameters = new HashMap<String, Object>();
+        var properties = new HashMap<String, Object>();
         properties.put("query", querySchema);
         parameters.put("type", "object");
         parameters.put("properties", properties);


### PR DESCRIPTION
## Summary

Apply Java `var` (local variable type inference) across the codebase where the type is obvious from the right-hand side expression.

## Changes

**3 main source files + 14 test files (17 files total)**

### Conversion patterns applied:
- Constructor calls: `Type x = new Type()` → `var x = new Type()`
- Diamond operator fill: `List<X> x = new ArrayList<>()` → `var x = new ArrayList<X>()`
- Cast expressions: `Type x = (Type) expr` → `var x = (Type) expr`

### Main sources:
- `CopilotClient.java` — 19 local variables converted
- `CopilotSession.java` — 7 local variables converted
- `JsonRpcClient.java` — 8 local variables converted

### Test sources:
CopilotClientTest, CopilotSessionTest, ToolsTest, SessionEventHandlingTest, SessionEventParserTest, SessionEventsE2ETest, PermissionsTest, HooksTest, CompactionTest, ErrorHandlingTest, AskUserTest, McpAndAgentsTest, CapiProxy, MetadataApiTest

## Verification
- Spotless formatting passes
- Compilation clean (main + test)
- All tests pass