### PR TITLE
Refactor: use var in documentation code examples

### DIFF
--- a/src/site/markdown/advanced.md
+++ b/src/site/markdown/advanced.md
@@ -127,7 +127,7 @@ var session = client.createSession(
 ).get();
 
 // Access the workspace where session state is persisted
-String workspace = session.getWorkspacePath();
+var workspace = session.getWorkspacePath();
 ```
 
 ### Compaction Events
@@ -247,7 +247,7 @@ var session = client.createSession(
             if (request.getChoices() != null && !request.getChoices().isEmpty()) {
                 System.out.println("Options: " + request.getChoices());
                 // Return one of the provided choices
-                String selectedChoice = request.getChoices().get(0);
+                var selectedChoice = request.getChoices().get(0);
                 return CompletableFuture.completedFuture(
                     new UserInputResponse()
                         .setAnswer(selectedChoice)
@@ -256,7 +256,7 @@ var session = client.createSession(
             }
             
             // Freeform input
-            String userAnswer = getUserInput(); // your input method
+            var userAnswer = getUserInput(); // your input method
             return CompletableFuture.completedFuture(
                 new UserInputResponse()
                     .setAnswer(userAnswer)
@@ -345,7 +345,7 @@ Subscribe to lifecycle events to be notified when sessions are created, deleted,
 ### Subscribing to All Lifecycle Events
 
 ```java
-AutoCloseable subscription = client.onLifecycle(event -> {
+var subscription = client.onLifecycle(event -> {
     System.out.println("Session " + event.getSessionId() + ": " + event.getType());
     
     if (event.getMetadata() != null) {
@@ -363,7 +363,7 @@ subscription.close();
 import com.github.copilot.sdk.json.SessionLifecycleEventTypes;
 
 // Listen only for session creation
-AutoCloseable subscription = client.onLifecycle(
+var subscription = client.onLifecycle(
     SessionLifecycleEventTypes.CREATED,
     event -> System.out.println("New session: " + event.getSessionId())
 );
@@ -385,7 +385,7 @@ When connecting to a server running in TUI+server mode (`--ui-server`), you can 
 ### Getting the Foreground Session
 
 ```java
-String sessionId = client.getForegroundSessionId().get();
+var sessionId = client.getForegroundSessionId().get();
 if (sessionId != null) {
     System.out.println("TUI is displaying session: " + sessionId);
 }

--- a/src/site/markdown/documentation.md
+++ b/src/site/markdown/documentation.md
@@ -217,9 +217,9 @@ done.get();
 Retrieve all messages and events from a session using `getMessages()`:
 
 ```java
-List<AbstractSessionEvent> history = session.getMessages().get();
+var history = session.getMessages().get();
 
-for (AbstractSessionEvent event : history) {
+for (var event : history) {
     switch (event) {
         case UserMessageEvent user -> 
             System.out.println("User: " + user.getData().getContent());
@@ -287,9 +287,9 @@ try {
 Query available models before creating a session:
 
 ```java
-List<ModelInfo> models = client.listModels().get();
+var models = client.listModels().get();
 
-for (ModelInfo model : models) {
+for (var model : models) {
     System.out.printf("%s (%s)%n", model.getId(), model.getName());
 }
 ```
@@ -329,10 +329,10 @@ System.out.println("Claude: " + future2.get().getData().getContent());
 
 ```java
 // Get the last session ID
-String lastSessionId = client.getLastSessionId().get();
+var lastSessionId = client.getLastSessionId().get();
 
 // Or list all sessions
-List<SessionMetadata> sessions = client.listSessions().get();
+var sessions = client.listSessions().get();
 
 // Resume a session
 var session = client.resumeSession(lastSessionId).get();

--- a/src/site/markdown/getting-started.md
+++ b/src/site/markdown/getting-started.md
@@ -179,13 +179,13 @@ public class ToolExample {
                     "required", List.of("city")
                 ),
                 invocation -> {
-                    Map<String, Object> params = invocation.getArguments();
-                    String city = (String) params.get("city");
+                    var params = invocation.getArguments();
+                    var city = (String) params.get("city");
                     
                     // In a real app, you'd call a weather API here
                     String[] conditions = {"sunny", "cloudy", "rainy", "partly cloudy"};
                     int temp = new Random().nextInt(30) + 50;
-                    String condition = conditions[new Random().nextInt(conditions.length)];
+                    var condition = conditions[new Random().nextInt(conditions.length)];
                     
                     return CompletableFuture.completedFuture(Map.of(
                         "city", city,
@@ -258,11 +258,11 @@ public class WeatherAssistant {
                     "required", List.of("city")
                 ),
                 invocation -> {
-                    Map<String, Object> params = invocation.getArguments();
-                    String city = (String) params.get("city");
+                    var params = invocation.getArguments();
+                    var city = (String) params.get("city");
                     String[] conditions = {"sunny", "cloudy", "rainy", "partly cloudy"};
                     int temp = new Random().nextInt(30) + 50;
-                    String condition = conditions[new Random().nextInt(conditions.length)];
+                    var condition = conditions[new Random().nextInt(conditions.length)];
                     return CompletableFuture.completedFuture(Map.of(
                         "city", city,
                         "temperature", temp + "°F",

--- a/src/site/markdown/hooks.md
+++ b/src/site/markdown/hooks.md
@@ -113,8 +113,8 @@ var hooks = new SessionHooks()
     .setOnPreToolUse((input, invocation) -> {
         if (input.getToolName().equals("search_code")) {
             // Add project root to search path
-            ObjectMapper mapper = new ObjectMapper();
-            ObjectNode modifiedArgs = mapper.createObjectNode();
+            var mapper = new ObjectMapper();
+            var modifiedArgs = mapper.createObjectNode();
             modifiedArgs.put("path", "/my/project/src");
             modifiedArgs.set("query", input.getToolArgs().get("query"));
             
@@ -283,7 +283,7 @@ var hooks = new SessionHooks()
         System.out.println("Session ended: " + input.getReason());
         
         // Clean up session resources
-        ResourceManager resources = sessionResources.remove(invocation.getSessionId());
+        var resources = sessionResources.remove(invocation.getSessionId());
         if (resources != null) {
             resources.close();
         }

--- a/src/site/markdown/mcp.md
+++ b/src/site/markdown/mcp.md
@@ -34,7 +34,7 @@ System.out.println(result.getData().getContent());
 Run a tool as a subprocess (stdin/stdout communication).
 
 ```java
-Map<String, Object> server = new HashMap<>();
+var server = new HashMap<String, Object>();
 server.put("type", "local");
 server.put("command", "node");
 server.put("args", List.of("./mcp-server.js"));


### PR DESCRIPTION
## Summary

Follow-up to PR #31 — applies `var` for local variable type inference to all Java code examples in the site documentation, for consistency with the source code and existing examples in `README.md`, `index.md`, and `jbang-example.java`.

## Changes

Converted explicit type declarations to `var` in Java code snippets across 5 documentation files:

| File | Changes |
|------|---------|
| `documentation.md` | `List<AbstractSessionEvent>` → `var`, `List<ModelInfo>` → `var`, `String` → `var`, `List<SessionMetadata>` → `var`, plus enhanced-for iterators |
| `hooks.md` | `ObjectMapper` → `var`, `ObjectNode` → `var`, `ResourceManager` → `var` |
| `mcp.md` | `Map<String, Object>` → `var` (with diamond type moved to RHS) |
| `getting-started.md` | `Map<String, Object>` → `var`, `String` → `var` (×4 across two tool examples) |
| `advanced.md` | `AutoCloseable` → `var` (×2), `String` → `var` (×4) |

Primitives (`int`) and bare array initializers (`String[]`) are left as-is since `var` cannot be used there.