### PR TITLE
Add EventErrorHandler for custom event handler error handling

### DIFF
--- a/src/main/java/com/github/copilot/sdk/EventErrorHandler.java
+++ b/src/main/java/com/github/copilot/sdk/EventErrorHandler.java
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+package com.github.copilot.sdk;
+
+import com.github.copilot.sdk.events.AbstractSessionEvent;
+
+/**
+ * A handler for errors thrown by event handlers during event dispatch.
+ * <p>
+ * When an event handler registered via
+ * {@link CopilotSession#on(java.util.function.Consumer)} or
+ * {@link CopilotSession#on(Class, java.util.function.Consumer)} throws an
+ * exception, the {@code EventErrorHandler} is invoked with the event that was
+ * being dispatched and the exception that was thrown.
+ *
+ * <p>
+ * The default behavior logs errors at {@link java.util.logging.Level#SEVERE}.
+ * You can override this to integrate with your own logging, metrics, or
+ * error-reporting systems:
+ *
+ * <pre>{@code
+ * session.setEventErrorHandler((event, exception) -> {
+ * 	metrics.increment("handler.errors");
+ * 	logger.error("Handler failed on {}: {}", event.getType(), exception.getMessage());
+ * });
+ * }</pre>
+ *
+ * <p>
+ * If the error handler itself throws an exception, that exception is silently
+ * caught and logged to prevent cascading failures.
+ *
+ * @see CopilotSession#setEventErrorHandler(EventErrorHandler)
+ * @since 1.0.8
+ */
+@FunctionalInterface
+public interface EventErrorHandler {
+
+    /**
+     * Called when an event handler throws an exception during event dispatch.
+     *
+     * @param event
+     *            the event that was being dispatched when the error occurred
+     * @param exception
+     *            the exception thrown by the event handler
+     */
+    void handleError(AbstractSessionEvent event, Exception exception);
+}

--- a/src/site/markdown/advanced.md
+++ b/src/site/markdown/advanced.md
@@ -442,3 +442,28 @@ session.on(AssistantMessageEvent.class, msg -> {
 > Go, and Python Copilot SDKs, which all catch handler errors per-handler. The
 > .NET SDK is an exception — handler errors propagate there and can prevent
 > subsequent handlers from running.
+
+### Custom Event Error Handler
+
+By default, handler exceptions are logged at `SEVERE` level using
+`java.util.logging`. You can replace this with a custom
+`EventErrorHandler` to integrate with your own logging, metrics, or
+error-reporting systems:
+
+```java
+session.setEventErrorHandler((event, exception) -> {
+    metrics.increment("handler.errors");
+    logger.error("Handler failed on {}: {}",
+        event.getType(), exception.getMessage());
+});
+```
+
+The error handler receives both the event that was being dispatched and the
+exception that was thrown. If the error handler itself throws, that exception
+is silently caught and logged to prevent cascading failures.
+
+Pass `null` to restore the default logging behavior:
+
+```java
+session.setEventErrorHandler(null);
+```

--- a/src/site/markdown/documentation.md
+++ b/src/site/markdown/documentation.md
@@ -59,7 +59,9 @@ For more control, subscribe to events and use `send()`:
 
 > **Exception isolation:** If a handler throws an exception, the SDK logs the
 > error and continues dispatching to remaining handlers. One misbehaving handler
-> will never prevent others from executing.
+> will never prevent others from executing. You can customize error handling with
+> `session.setEventErrorHandler()` — see the
+> [Advanced Usage](advanced.html#Custom_Event_Error_Handler) guide.
 
 ```java
 var done = new CompletableFuture<Void>();


### PR DESCRIPTION
## Summary

Introduces a session-level `EventErrorHandler` functional interface that lets developers react to event handler exceptions programmatically, instead of relying on the default `SEVERE` logging.

## Motivation

When an event handler throws an exception, the SDK currently catches it and logs at `SEVERE` level. This is fine for development, but production applications often need to integrate with custom metrics, alerting, or error-reporting systems. This PR adds an opt-in hook for that.

## Changes

### New API

- **`EventErrorHandler`** — `@FunctionalInterface` in `com.github.copilot.sdk` with `handleError(AbstractSessionEvent event, Exception exception)`
- **`CopilotSession.setEventErrorHandler(EventErrorHandler)`** — sets a custom handler; pass `null` to restore default logging

### Implementation

- `dispatchEvent()` now delegates to the custom error handler when set, falling back to `LOG.log(Level.SEVERE, ...)` when no custom handler is configured
- If the error handler itself throws, that exception is silently caught and logged to prevent cascading failures

### Tests (6 new)

- `testDefaultErrorHandlerLogsException` — backward-compatible default behavior
- `testCustomEventErrorHandlerReceivesEventAndException` — handler gets correct event + exception
- `testCustomErrorHandlerReplacesDefaultLogging` — multiple errors all reach custom handler
- `testErrorHandlerItselfThrowingDoesNotBreakDispatch` — resilience when error handler throws
- `testSetEventErrorHandlerToNullRestoresDefaultBehavior` — null resets to default logging
- `testErrorHandlerReceivesCorrectEventType` — different event types are passed correctly

### Documentation

- Updated `advanced.md` with new "Custom Event Error Handler" subsection
- Updated `documentation.md` to mention `setEventErrorHandler()` in the exception isolation callout
- Full Javadoc on `EventErrorHandler`, `setEventErrorHandler()`, and updated `dispatchEvent()`

## Usage

```java
session.setEventErrorHandler((event, exception) -> {
    metrics.increment("handler.errors");
    logger.error("Handler failed on {}: {}",
        event.getType(), exception.getMessage());
});
```