### PR TITLE
Fix cliUrl to auto-correct useStdio for backend service scenarios

### DIFF
--- a/src/main/java/com/github/copilot/sdk/CliServerManager.java
+++ b/src/main/java/com/github/copilot/sdk/CliServerManager.java
@@ -127,17 +127,15 @@ final class CliServerManager {
      *             if connection fails
      */
     JsonRpcClient connectToServer(Process process, String tcpHost, Integer tcpPort) throws IOException {
-        if (options.isUseStdio()) {
-            if (process == null) {
-                throw new IllegalStateException("CLI process not started");
-            }
-            return JsonRpcClient.fromProcess(process);
-        } else {
-            if (tcpHost == null || tcpPort == null) {
-                throw new IllegalStateException("Cannot connect because TCP host or port are not available");
-            }
+        if (tcpHost != null && tcpPort != null) {
+            // TCP mode: external server or child process with explicit port
             Socket socket = new Socket(tcpHost, tcpPort);
             return JsonRpcClient.fromSocket(socket);
+        } else if (process != null) {
+            // Stdio mode: child process
+            return JsonRpcClient.fromProcess(process);
+        } else {
+            throw new IllegalStateException("Cannot connect: no process for stdio and no host:port for TCP");
         }
     }
 

--- a/src/main/java/com/github/copilot/sdk/CopilotClient.java
+++ b/src/main/java/com/github/copilot/sdk/CopilotClient.java
@@ -90,10 +90,15 @@ public final class CopilotClient implements AutoCloseable {
     public CopilotClient(CopilotClientOptions options) {
         this.options = options != null ? options : new CopilotClientOptions();
 
-        // Validate mutually exclusive options
+        // When cliUrl is set, auto-correct useStdio since we're connecting via TCP
+        if (this.options.getCliUrl() != null && !this.options.getCliUrl().isEmpty()) {
+            this.options.setUseStdio(false);
+        }
+
+        // Validate mutually exclusive options: cliUrl and cliPath cannot both be set
         if (this.options.getCliUrl() != null && !this.options.getCliUrl().isEmpty()
-                && (this.options.isUseStdio() || this.options.getCliPath() != null)) {
-            throw new IllegalArgumentException("CliUrl is mutually exclusive with UseStdio and CliPath");
+                && this.options.getCliPath() != null) {
+            throw new IllegalArgumentException("CliUrl is mutually exclusive with CliPath");
         }
 
         // Validate auth options with external server

--- a/src/test/java/com/github/copilot/sdk/CopilotClientTest.java
+++ b/src/test/java/com/github/copilot/sdk/CopilotClientTest.java
@@ -96,16 +96,29 @@ public class CopilotClientTest {
     }
 
     @Test
-    void testCliUrlMutualExclusion() {
+    void testCliUrlAutoCorrectsUseStdio() {
         var options = new CopilotClientOptions().setCliUrl("localhost:3000").setUseStdio(true);
 
-        assertThrows(IllegalArgumentException.class, () -> new CopilotClient(options));
+        // Should NOT throw - useStdio is auto-corrected to false when cliUrl is set
+        var client = new CopilotClient(options);
+        assertFalse(options.isUseStdio(), "useStdio should be auto-corrected to false when cliUrl is set");
+        client.close();
+    }
+
+    @Test
+    void testCliUrlOnlyConstruction() {
+        var options = new CopilotClientOptions().setCliUrl("localhost:4321");
+
+        // Should work without explicitly setting useStdio to false
+        var client = new CopilotClient(options);
+        assertEquals(ConnectionState.DISCONNECTED, client.getState());
+        assertFalse(options.isUseStdio(), "useStdio should be auto-corrected to false when cliUrl is set");
+        client.close();
     }
 
     @Test
     void testCliUrlMutualExclusionWithCliPath() {
-        var options = new CopilotClientOptions().setCliUrl("localhost:3000").setCliPath("/path/to/cli")
-                .setUseStdio(false);
+        var options = new CopilotClientOptions().setCliUrl("localhost:3000").setCliPath("/path/to/cli");
 
         assertThrows(IllegalArgumentException.class, () -> new CopilotClient(options));
     }
@@ -194,16 +207,14 @@ public class CopilotClientTest {
 
     @Test
     void testGithubTokenWithCliUrlThrows() {
-        var options = new CopilotClientOptions().setCliUrl("localhost:8080").setGithubToken("gho_test_token")
-                .setUseStdio(false);
+        var options = new CopilotClientOptions().setCliUrl("localhost:8080").setGithubToken("gho_test_token");
 
         assertThrows(IllegalArgumentException.class, () -> new CopilotClient(options));
     }
 
     @Test
     void testUseLoggedInUserWithCliUrlThrows() {
-        var options = new CopilotClientOptions().setCliUrl("localhost:8080").setUseLoggedInUser(false)
-                .setUseStdio(false);
+        var options = new CopilotClientOptions().setCliUrl("localhost:8080").setUseLoggedInUser(false);
 
         assertThrows(IllegalArgumentException.class, () -> new CopilotClient(options));
     }


### PR DESCRIPTION
## Summary\n\nWhen `cliUrl` is set (connecting to an external CLI server), `useStdio` is now automatically set to `false` since TCP is inherently required.\n\nPreviously, users had to explicitly call `setUseStdio(false)` alongside `setCliUrl()`, which contradicted the `setup.md` documentation that shows:\n\n```java\nvar options = new CopilotClientOptions()\n    .setCliUrl(\"localhost:4321\");\n```\n\n## Changes\n\n- **CopilotClient**: Auto-corrects `useStdio` to `false` when `cliUrl` is provided. Simplified mutual exclusion validation to only reject `cliUrl` + `cliPath`.\n- **CliServerManager**: Made `connectToServer` parameter-driven (routes by host/port availability) instead of flag-driven.\n- **CopilotClientTest**: Updated tests for new behavior, added `testCliUrlAutoCorrectsUseStdio` and `testCliUrlOnlyConstruction`.\n\n## Testing\n\nAll 14 `CopilotClientTest` tests pass. Full test suite passes (1 pre-existing unrelated E2E failure in `SessionEventsE2ETest`).