### PR TITLE
Extract shell scripts from commit-as-pull-request prompt

### DIFF
--- a/.github/scripts/ci/commit-and-push.sh
+++ b/.github/scripts/ci/commit-and-push.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Verify changes, optionally run the code formatter, create a branch,
+# stage all changes, commit, and push to origin.
+#
+# Usage:
+#   ./commit-and-push.sh <branch-name> <commit-message> [--skip-format]
+#
+# Arguments:
+#   branch-name     The branch to create (e.g., fix/my-change)
+#   commit-message  The commit message (may include newlines via $'...' syntax)
+#   --skip-format   Skip running mvn spotless:apply
+#
+# Exit codes:
+#   0  Success
+#   1  No changes to commit / general error
+#   2  Push failed
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <branch-name> <commit-message> [--skip-format]" >&2
+  exit 1
+fi
+
+branch_name="$1"
+commit_message="$2"
+skip_format="${3:-}"
+
+# -- Step 1: Verify there are changes to commit ---------------------------------
+if [[ -z "$(git status --porcelain)" ]]; then
+  echo "ERROR: No uncommitted changes found. Nothing to commit." >&2
+  exit 1
+fi
+
+echo "✓ Uncommitted changes detected."
+
+# -- Step 4: Run code formatter (if applicable) ----------------------------------
+if [[ "$skip_format" != "--skip-format" ]] && [[ -f pom.xml ]]; then
+  if grep -q 'spotless-maven-plugin' pom.xml 2>/dev/null; then
+    echo "Running Spotless formatter..."
+    mvn -q spotless:apply
+    echo "✓ Spotless formatting applied."
+  fi
+fi
+
+# -- Step 5: Create branch, stage, and commit ------------------------------------
+# If the branch already exists locally, append a numeric suffix
+actual_branch="$branch_name"
+suffix=2
+while git show-ref --verify --quiet "refs/heads/$actual_branch" 2>/dev/null; do
+  actual_branch="${branch_name}-${suffix}"
+  suffix=$((suffix + 1))
+done
+
+git checkout -b "$actual_branch"
+git add -A
+git commit -m "$commit_message"
+
+echo "✓ Committed on branch '$actual_branch'."
+
+# -- Step 6: Push the branch -----------------------------------------------------
+if ! git push -u origin "$actual_branch" 2>&1; then
+  echo "ERROR: Push failed." >&2
+  exit 2
+fi
+
+# Verify the push actually transferred the commit
+remote_sha=$(git ls-remote origin "refs/heads/$actual_branch" | awk '{print $1}')
+local_sha=$(git rev-parse HEAD)
+
+if [[ "$remote_sha" != "$local_sha" ]]; then
+  echo "WARNING: Remote SHA does not match local. Retrying push..." >&2
+  git push -u origin "$actual_branch" 2>&1 || { echo "ERROR: Retry push failed." >&2; exit 2; }
+fi
+
+echo "✓ Pushed to origin/$actual_branch."
+echo "BRANCH_NAME=$actual_branch"

--- a/.github/scripts/ci/parse-repo-info.sh
+++ b/.github/scripts/ci/parse-repo-info.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Parse the GitHub owner and repository name from the git remote URL.
+# Outputs two lines: owner on the first, repo on the second.
+# Handles both HTTPS and SSH remote URL formats.
+#
+# Usage:
+#   eval "$(./parse-repo-info.sh)"
+#   echo "Owner: $REPO_OWNER  Repo: $REPO_NAME"
+
+set -euo pipefail
+
+remote_url=$(git remote get-url origin 2>/dev/null) || {
+  echo "ERROR: No git remote named 'origin' found." >&2
+  exit 1
+}
+
+# Strip trailing .git if present
+remote_url="${remote_url%.git}"
+
+if [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/]+)$ ]]; then
+  owner="${BASH_REMATCH[1]}"
+  repo="${BASH_REMATCH[2]}"
+else
+  echo "ERROR: Could not parse owner/repo from remote URL: $remote_url" >&2
+  exit 1
+fi
+
+echo "REPO_OWNER=$owner"
+echo "REPO_NAME=$repo"

--- a/.github/scripts/ci/sync-after-merge.sh
+++ b/.github/scripts/ci/sync-after-merge.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# After a PR has been merged, sync the local main branch and
+# optionally delete the local feature branch.
+#
+# Usage:
+#   ./sync-after-merge.sh [branch-name]
+#
+# Arguments:
+#   branch-name   The local branch to delete (optional). Skipped if omitted.
+
+set -euo pipefail
+
+branch_name="${1:-}"
+
+# -- Step 9: Sync local main ----------------------------------------------------
+git checkout main
+git pull
+
+echo "✓ Local main is up to date."
+
+# -- Step 10: Clean up the local branch ------------------------------------------
+if [[ -n "$branch_name" ]]; then
+  if git show-ref --verify --quiet "refs/heads/$branch_name" 2>/dev/null; then
+    git branch -d "$branch_name" 2>/dev/null || git branch -D "$branch_name"
+    echo "✓ Deleted local branch '$branch_name'."
+  else
+    echo "Branch '$branch_name' does not exist locally (already cleaned up)."
+  fi
+fi


### PR DESCRIPTION
## Summary\n\nExtract the inline git commands from the `commit-as-pull-request.prompt.md` into reusable shell scripts. This simplifies the prompt from 10 steps down to 6, with the git plumbing delegated to scripts that handle edge cases (branch collisions, push verification, formatter detection).\n\n## Changes\n\n- **`.github/scripts/ci/parse-repo-info.sh`** — Parses `REPO_OWNER` and `REPO_NAME` from `git remote get-url origin` (supports HTTPS and SSH)\n- **`.github/scripts/ci/commit-and-push.sh`** — Verifies changes exist, optionally runs Spotless, creates branch (with collision handling), stages, commits, and pushes\n- **`.github/scripts/ci/sync-after-merge.sh`** — Checks out main, pulls, and deletes the feature branch\n- **`.github/prompts/commit-as-pull-request.prompt.md`** — Rewritten to reference the scripts; reduced from 10 steps to 6\n\n## Testing\n\nThe `commit-and-push.sh` and `parse-repo-info.sh` scripts were used to create this very PR, confirming they work end-to-end."