### PR TITLE
Convert 25 simple inner Data classes to Java records

### DIFF
--- a/src/main/java/com/github/copilot/sdk/CopilotSession.java
+++ b/src/main/java/com/github/copilot/sdk/CopilotSession.java
@@ -338,7 +338,7 @@ public final class CopilotSession implements AutoCloseable {
             } else if (evt instanceof SessionIdleEvent) {
                 future.complete(lastAssistantMessage.get());
             } else if (evt instanceof SessionErrorEvent errorEvent) {
-                String message = errorEvent.getData() != null ? errorEvent.getData().getMessage() : "session error";
+                String message = errorEvent.getData() != null ? errorEvent.getData().message() : "session error";
                 future.completeExceptionally(new RuntimeException("Session error: " + message));
             }
         };
@@ -463,7 +463,7 @@ public final class CopilotSession implements AutoCloseable {
      *
      * // Handle streaming deltas
      * session.on(AssistantMessageDeltaEvent.class, delta -> {
-     * 	System.out.print(delta.getData().getDeltaContent());
+     * 	System.out.print(delta.getData().deltaContent());
      * });
      * }</pre>
      *

--- a/src/main/java/com/github/copilot/sdk/events/AbortEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/AbortEvent.java
@@ -32,17 +32,6 @@ public final class AbortEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class AbortData {
-
-        @JsonProperty("reason")
-        private String reason;
-
-        public String getReason() {
-            return reason;
-        }
-
-        public void setReason(String reason) {
-            this.reason = reason;
-        }
+    public record AbortData(@JsonProperty("reason") String reason) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/AssistantIntentEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/AssistantIntentEvent.java
@@ -32,17 +32,6 @@ public final class AssistantIntentEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class AssistantIntentData {
-
-        @JsonProperty("intent")
-        private String intent;
-
-        public String getIntent() {
-            return intent;
-        }
-
-        public void setIntent(String intent) {
-            this.intent = intent;
-        }
+    public record AssistantIntentData(@JsonProperty("intent") String intent) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/AssistantMessageDeltaEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/AssistantMessageDeltaEvent.java
@@ -32,50 +32,9 @@ public final class AssistantMessageDeltaEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class AssistantMessageDeltaData {
-
-        @JsonProperty("messageId")
-        private String messageId;
-
-        @JsonProperty("deltaContent")
-        private String deltaContent;
-
-        @JsonProperty("totalResponseSizeBytes")
-        private Double totalResponseSizeBytes;
-
-        @JsonProperty("parentToolCallId")
-        private String parentToolCallId;
-
-        public String getMessageId() {
-            return messageId;
-        }
-
-        public void setMessageId(String messageId) {
-            this.messageId = messageId;
-        }
-
-        public String getDeltaContent() {
-            return deltaContent;
-        }
-
-        public void setDeltaContent(String deltaContent) {
-            this.deltaContent = deltaContent;
-        }
-
-        public Double getTotalResponseSizeBytes() {
-            return totalResponseSizeBytes;
-        }
-
-        public void setTotalResponseSizeBytes(Double totalResponseSizeBytes) {
-            this.totalResponseSizeBytes = totalResponseSizeBytes;
-        }
-
-        public String getParentToolCallId() {
-            return parentToolCallId;
-        }
-
-        public void setParentToolCallId(String parentToolCallId) {
-            this.parentToolCallId = parentToolCallId;
-        }
+    public record AssistantMessageDeltaData(@JsonProperty("messageId") String messageId,
+            @JsonProperty("deltaContent") String deltaContent,
+            @JsonProperty("totalResponseSizeBytes") Double totalResponseSizeBytes,
+            @JsonProperty("parentToolCallId") String parentToolCallId) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/AssistantReasoningDeltaEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/AssistantReasoningDeltaEvent.java
@@ -32,28 +32,7 @@ public final class AssistantReasoningDeltaEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class AssistantReasoningDeltaData {
-
-        @JsonProperty("reasoningId")
-        private String reasoningId;
-
-        @JsonProperty("deltaContent")
-        private String deltaContent;
-
-        public String getReasoningId() {
-            return reasoningId;
-        }
-
-        public void setReasoningId(String reasoningId) {
-            this.reasoningId = reasoningId;
-        }
-
-        public String getDeltaContent() {
-            return deltaContent;
-        }
-
-        public void setDeltaContent(String deltaContent) {
-            this.deltaContent = deltaContent;
-        }
+    public record AssistantReasoningDeltaData(@JsonProperty("reasoningId") String reasoningId,
+            @JsonProperty("deltaContent") String deltaContent) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/AssistantReasoningEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/AssistantReasoningEvent.java
@@ -32,28 +32,7 @@ public final class AssistantReasoningEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class AssistantReasoningData {
-
-        @JsonProperty("reasoningId")
-        private String reasoningId;
-
-        @JsonProperty("content")
-        private String content;
-
-        public String getReasoningId() {
-            return reasoningId;
-        }
-
-        public void setReasoningId(String reasoningId) {
-            this.reasoningId = reasoningId;
-        }
-
-        public String getContent() {
-            return content;
-        }
-
-        public void setContent(String content) {
-            this.content = content;
-        }
+    public record AssistantReasoningData(@JsonProperty("reasoningId") String reasoningId,
+            @JsonProperty("content") String content) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/AssistantTurnEndEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/AssistantTurnEndEvent.java
@@ -32,17 +32,6 @@ public final class AssistantTurnEndEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class AssistantTurnEndData {
-
-        @JsonProperty("turnId")
-        private String turnId;
-
-        public String getTurnId() {
-            return turnId;
-        }
-
-        public void setTurnId(String turnId) {
-            this.turnId = turnId;
-        }
+    public record AssistantTurnEndData(@JsonProperty("turnId") String turnId) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/AssistantTurnStartEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/AssistantTurnStartEvent.java
@@ -32,17 +32,6 @@ public final class AssistantTurnStartEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class AssistantTurnStartData {
-
-        @JsonProperty("turnId")
-        private String turnId;
-
-        public String getTurnId() {
-            return turnId;
-        }
-
-        public void setTurnId(String turnId) {
-            this.turnId = turnId;
-        }
+    public record AssistantTurnStartData(@JsonProperty("turnId") String turnId) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/PendingMessagesModifiedEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/PendingMessagesModifiedEvent.java
@@ -32,7 +32,6 @@ public final class PendingMessagesModifiedEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class PendingMessagesModifiedData {
-        // Empty data
+    public record PendingMessagesModifiedData() {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/SessionCompactionCompleteEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/SessionCompactionCompleteEvent.java
@@ -32,178 +32,23 @@ public final class SessionCompactionCompleteEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SessionCompactionCompleteData {
-
-        @JsonProperty("success")
-        private boolean success;
-
-        @JsonProperty("error")
-        private String error;
-
-        @JsonProperty("preCompactionTokens")
-        private Double preCompactionTokens;
-
-        @JsonProperty("postCompactionTokens")
-        private Double postCompactionTokens;
-
-        @JsonProperty("preCompactionMessagesLength")
-        private Double preCompactionMessagesLength;
-
-        @JsonProperty("messagesRemoved")
-        private Double messagesRemoved;
-
-        @JsonProperty("tokensRemoved")
-        private Double tokensRemoved;
-
-        @JsonProperty("summaryContent")
-        private String summaryContent;
-
-        @JsonProperty("checkpointNumber")
-        private Double checkpointNumber;
-
-        @JsonProperty("checkpointPath")
-        private String checkpointPath;
-
-        @JsonProperty("compactionTokensUsed")
-        private CompactionTokensUsed compactionTokensUsed;
-
-        @JsonProperty("requestId")
-        private String requestId;
-
-        public boolean isSuccess() {
-            return success;
-        }
-
-        public void setSuccess(boolean success) {
-            this.success = success;
-        }
-
-        public String getError() {
-            return error;
-        }
-
-        public void setError(String error) {
-            this.error = error;
-        }
-
-        public Double getPreCompactionTokens() {
-            return preCompactionTokens;
-        }
-
-        public void setPreCompactionTokens(Double preCompactionTokens) {
-            this.preCompactionTokens = preCompactionTokens;
-        }
-
-        public Double getPostCompactionTokens() {
-            return postCompactionTokens;
-        }
-
-        public void setPostCompactionTokens(Double postCompactionTokens) {
-            this.postCompactionTokens = postCompactionTokens;
-        }
-
-        public Double getPreCompactionMessagesLength() {
-            return preCompactionMessagesLength;
-        }
-
-        public void setPreCompactionMessagesLength(Double preCompactionMessagesLength) {
-            this.preCompactionMessagesLength = preCompactionMessagesLength;
-        }
-
-        public Double getMessagesRemoved() {
-            return messagesRemoved;
-        }
-
-        public void setMessagesRemoved(Double messagesRemoved) {
-            this.messagesRemoved = messagesRemoved;
-        }
-
-        public Double getTokensRemoved() {
-            return tokensRemoved;
-        }
-
-        public void setTokensRemoved(Double tokensRemoved) {
-            this.tokensRemoved = tokensRemoved;
-        }
-
-        public String getSummaryContent() {
-            return summaryContent;
-        }
-
-        public void setSummaryContent(String summaryContent) {
-            this.summaryContent = summaryContent;
-        }
-
-        public Double getCheckpointNumber() {
-            return checkpointNumber;
-        }
-
-        public void setCheckpointNumber(Double checkpointNumber) {
-            this.checkpointNumber = checkpointNumber;
-        }
-
-        public String getCheckpointPath() {
-            return checkpointPath;
-        }
-
-        public void setCheckpointPath(String checkpointPath) {
-            this.checkpointPath = checkpointPath;
-        }
-
-        public CompactionTokensUsed getCompactionTokensUsed() {
-            return compactionTokensUsed;
-        }
-
-        public void setCompactionTokensUsed(CompactionTokensUsed compactionTokensUsed) {
-            this.compactionTokensUsed = compactionTokensUsed;
-        }
-
-        public String getRequestId() {
-            return requestId;
-        }
-
-        public void setRequestId(String requestId) {
-            this.requestId = requestId;
-        }
+    public record SessionCompactionCompleteData(@JsonProperty("success") boolean success,
+            @JsonProperty("error") String error, @JsonProperty("preCompactionTokens") Double preCompactionTokens,
+            @JsonProperty("postCompactionTokens") Double postCompactionTokens,
+            @JsonProperty("preCompactionMessagesLength") Double preCompactionMessagesLength,
+            @JsonProperty("messagesRemoved") Double messagesRemoved,
+            @JsonProperty("tokensRemoved") Double tokensRemoved, @JsonProperty("summaryContent") String summaryContent,
+            @JsonProperty("checkpointNumber") Double checkpointNumber,
+            @JsonProperty("checkpointPath") String checkpointPath,
+            @JsonProperty("compactionTokensUsed") CompactionTokensUsed compactionTokensUsed,
+            @JsonProperty("requestId") String requestId) {
     }
 
     /**
      * Token usage information for the compaction operation.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class CompactionTokensUsed {
-
-        @JsonProperty("input")
-        private double input;
-
-        @JsonProperty("output")
-        private double output;
-
-        @JsonProperty("cachedInput")
-        private double cachedInput;
-
-        public double getInput() {
-            return input;
-        }
-
-        public void setInput(double input) {
-            this.input = input;
-        }
-
-        public double getOutput() {
-            return output;
-        }
-
-        public void setOutput(double output) {
-            this.output = output;
-        }
-
-        public double getCachedInput() {
-            return cachedInput;
-        }
-
-        public void setCachedInput(double cachedInput) {
-            this.cachedInput = cachedInput;
-        }
+    public record CompactionTokensUsed(@JsonProperty("input") double input, @JsonProperty("output") double output,
+            @JsonProperty("cachedInput") double cachedInput) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/SessionCompactionStartEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/SessionCompactionStartEvent.java
@@ -32,7 +32,6 @@ public final class SessionCompactionStartEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SessionCompactionStartData {
-        // Empty data
+    public record SessionCompactionStartData() {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/SessionErrorEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/SessionErrorEvent.java
@@ -32,61 +32,8 @@ public final class SessionErrorEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SessionErrorData {
-
-        @JsonProperty("errorType")
-        private String errorType;
-
-        @JsonProperty("message")
-        private String message;
-
-        @JsonProperty("stack")
-        private String stack;
-
-        @JsonProperty("statusCode")
-        private Double statusCode;
-
-        @JsonProperty("providerCallId")
-        private String providerCallId;
-
-        public String getErrorType() {
-            return errorType;
-        }
-
-        public void setErrorType(String errorType) {
-            this.errorType = errorType;
-        }
-
-        public String getMessage() {
-            return message;
-        }
-
-        public void setMessage(String message) {
-            this.message = message;
-        }
-
-        public String getStack() {
-            return stack;
-        }
-
-        public void setStack(String stack) {
-            this.stack = stack;
-        }
-
-        public Double getStatusCode() {
-            return statusCode;
-        }
-
-        public void setStatusCode(Double statusCode) {
-            this.statusCode = statusCode;
-        }
-
-        public String getProviderCallId() {
-            return providerCallId;
-        }
-
-        public void setProviderCallId(String providerCallId) {
-            this.providerCallId = providerCallId;
-        }
+    public record SessionErrorData(@JsonProperty("errorType") String errorType, @JsonProperty("message") String message,
+            @JsonProperty("stack") String stack, @JsonProperty("statusCode") Double statusCode,
+            @JsonProperty("providerCallId") String providerCallId) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/SessionHandoffEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/SessionHandoffEvent.java
@@ -34,109 +34,14 @@ public final class SessionHandoffEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SessionHandoffData {
-
-        @JsonProperty("handoffTime")
-        private OffsetDateTime handoffTime;
-
-        @JsonProperty("sourceType")
-        private String sourceType;
-
-        @JsonProperty("repository")
-        private Repository repository;
-
-        @JsonProperty("context")
-        private String context;
-
-        @JsonProperty("summary")
-        private String summary;
-
-        @JsonProperty("remoteSessionId")
-        private String remoteSessionId;
-
-        public OffsetDateTime getHandoffTime() {
-            return handoffTime;
-        }
-
-        public void setHandoffTime(OffsetDateTime handoffTime) {
-            this.handoffTime = handoffTime;
-        }
-
-        public String getSourceType() {
-            return sourceType;
-        }
-
-        public void setSourceType(String sourceType) {
-            this.sourceType = sourceType;
-        }
-
-        public Repository getRepository() {
-            return repository;
-        }
-
-        public void setRepository(Repository repository) {
-            this.repository = repository;
-        }
-
-        public String getContext() {
-            return context;
-        }
-
-        public void setContext(String context) {
-            this.context = context;
-        }
-
-        public String getSummary() {
-            return summary;
-        }
-
-        public void setSummary(String summary) {
-            this.summary = summary;
-        }
-
-        public String getRemoteSessionId() {
-            return remoteSessionId;
-        }
-
-        public void setRemoteSessionId(String remoteSessionId) {
-            this.remoteSessionId = remoteSessionId;
-        }
+    public record SessionHandoffData(@JsonProperty("handoffTime") OffsetDateTime handoffTime,
+            @JsonProperty("sourceType") String sourceType, @JsonProperty("repository") Repository repository,
+            @JsonProperty("context") String context, @JsonProperty("summary") String summary,
+            @JsonProperty("remoteSessionId") String remoteSessionId) {
 
         @JsonIgnoreProperties(ignoreUnknown = true)
-        public static class Repository {
-
-            @JsonProperty("owner")
-            private String owner;
-
-            @JsonProperty("name")
-            private String name;
-
-            @JsonProperty("branch")
-            private String branch;
-
-            public String getOwner() {
-                return owner;
-            }
-
-            public void setOwner(String owner) {
-                this.owner = owner;
-            }
-
-            public String getName() {
-                return name;
-            }
-
-            public void setName(String name) {
-                this.name = name;
-            }
-
-            public String getBranch() {
-                return branch;
-            }
-
-            public void setBranch(String branch) {
-                this.branch = branch;
-            }
+        public record Repository(@JsonProperty("owner") String owner, @JsonProperty("name") String name,
+                @JsonProperty("branch") String branch) {
         }
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/SessionIdleEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/SessionIdleEvent.java
@@ -32,7 +32,6 @@ public final class SessionIdleEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SessionIdleData {
-        // Empty data
+    public record SessionIdleData() {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/SessionInfoEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/SessionInfoEvent.java
@@ -32,28 +32,6 @@ public final class SessionInfoEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SessionInfoData {
-
-        @JsonProperty("infoType")
-        private String infoType;
-
-        @JsonProperty("message")
-        private String message;
-
-        public String getInfoType() {
-            return infoType;
-        }
-
-        public void setInfoType(String infoType) {
-            this.infoType = infoType;
-        }
-
-        public String getMessage() {
-            return message;
-        }
-
-        public void setMessage(String message) {
-            this.message = message;
-        }
+    public record SessionInfoData(@JsonProperty("infoType") String infoType, @JsonProperty("message") String message) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/SessionModelChangeEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/SessionModelChangeEvent.java
@@ -32,28 +32,7 @@ public final class SessionModelChangeEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SessionModelChangeData {
-
-        @JsonProperty("previousModel")
-        private String previousModel;
-
-        @JsonProperty("newModel")
-        private String newModel;
-
-        public String getPreviousModel() {
-            return previousModel;
-        }
-
-        public void setPreviousModel(String previousModel) {
-            this.previousModel = previousModel;
-        }
-
-        public String getNewModel() {
-            return newModel;
-        }
-
-        public void setNewModel(String newModel) {
-            this.newModel = newModel;
-        }
+    public record SessionModelChangeData(@JsonProperty("previousModel") String previousModel,
+            @JsonProperty("newModel") String newModel) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/SessionResumeEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/SessionResumeEvent.java
@@ -34,28 +34,7 @@ public final class SessionResumeEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SessionResumeData {
-
-        @JsonProperty("resumeTime")
-        private OffsetDateTime resumeTime;
-
-        @JsonProperty("eventCount")
-        private double eventCount;
-
-        public OffsetDateTime getResumeTime() {
-            return resumeTime;
-        }
-
-        public void setResumeTime(OffsetDateTime resumeTime) {
-            this.resumeTime = resumeTime;
-        }
-
-        public double getEventCount() {
-            return eventCount;
-        }
-
-        public void setEventCount(double eventCount) {
-            this.eventCount = eventCount;
-        }
+    public record SessionResumeData(@JsonProperty("resumeTime") OffsetDateTime resumeTime,
+            @JsonProperty("eventCount") double eventCount) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/SessionSnapshotRewindEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/SessionSnapshotRewindEvent.java
@@ -34,28 +34,7 @@ public final class SessionSnapshotRewindEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SessionSnapshotRewindData {
-
-        @JsonProperty("upToEventId")
-        private String upToEventId;
-
-        @JsonProperty("eventsRemoved")
-        private int eventsRemoved;
-
-        public String getUpToEventId() {
-            return upToEventId;
-        }
-
-        public void setUpToEventId(String upToEventId) {
-            this.upToEventId = upToEventId;
-        }
-
-        public int getEventsRemoved() {
-            return eventsRemoved;
-        }
-
-        public void setEventsRemoved(int eventsRemoved) {
-            this.eventsRemoved = eventsRemoved;
-        }
+    public record SessionSnapshotRewindData(@JsonProperty("upToEventId") String upToEventId,
+            @JsonProperty("eventsRemoved") int eventsRemoved) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/SessionStartEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/SessionStartEvent.java
@@ -34,72 +34,8 @@ public final class SessionStartEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SessionStartData {
-
-        @JsonProperty("sessionId")
-        private String sessionId;
-
-        @JsonProperty("version")
-        private double version;
-
-        @JsonProperty("producer")
-        private String producer;
-
-        @JsonProperty("copilotVersion")
-        private String copilotVersion;
-
-        @JsonProperty("startTime")
-        private OffsetDateTime startTime;
-
-        @JsonProperty("selectedModel")
-        private String selectedModel;
-
-        public String getSessionId() {
-            return sessionId;
-        }
-
-        public void setSessionId(String sessionId) {
-            this.sessionId = sessionId;
-        }
-
-        public double getVersion() {
-            return version;
-        }
-
-        public void setVersion(double version) {
-            this.version = version;
-        }
-
-        public String getProducer() {
-            return producer;
-        }
-
-        public void setProducer(String producer) {
-            this.producer = producer;
-        }
-
-        public String getCopilotVersion() {
-            return copilotVersion;
-        }
-
-        public void setCopilotVersion(String copilotVersion) {
-            this.copilotVersion = copilotVersion;
-        }
-
-        public OffsetDateTime getStartTime() {
-            return startTime;
-        }
-
-        public void setStartTime(OffsetDateTime startTime) {
-            this.startTime = startTime;
-        }
-
-        public String getSelectedModel() {
-            return selectedModel;
-        }
-
-        public void setSelectedModel(String selectedModel) {
-            this.selectedModel = selectedModel;
-        }
+    public record SessionStartData(@JsonProperty("sessionId") String sessionId, @JsonProperty("version") double version,
+            @JsonProperty("producer") String producer, @JsonProperty("copilotVersion") String copilotVersion,
+            @JsonProperty("startTime") OffsetDateTime startTime, @JsonProperty("selectedModel") String selectedModel) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/SessionTruncationEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/SessionTruncationEvent.java
@@ -32,94 +32,13 @@ public final class SessionTruncationEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SessionTruncationData {
-
-        @JsonProperty("tokenLimit")
-        private double tokenLimit;
-
-        @JsonProperty("preTruncationTokensInMessages")
-        private double preTruncationTokensInMessages;
-
-        @JsonProperty("preTruncationMessagesLength")
-        private double preTruncationMessagesLength;
-
-        @JsonProperty("postTruncationTokensInMessages")
-        private double postTruncationTokensInMessages;
-
-        @JsonProperty("postTruncationMessagesLength")
-        private double postTruncationMessagesLength;
-
-        @JsonProperty("tokensRemovedDuringTruncation")
-        private double tokensRemovedDuringTruncation;
-
-        @JsonProperty("messagesRemovedDuringTruncation")
-        private double messagesRemovedDuringTruncation;
-
-        @JsonProperty("performedBy")
-        private String performedBy;
-
-        public double getTokenLimit() {
-            return tokenLimit;
-        }
-
-        public void setTokenLimit(double tokenLimit) {
-            this.tokenLimit = tokenLimit;
-        }
-
-        public double getPreTruncationTokensInMessages() {
-            return preTruncationTokensInMessages;
-        }
-
-        public void setPreTruncationTokensInMessages(double preTruncationTokensInMessages) {
-            this.preTruncationTokensInMessages = preTruncationTokensInMessages;
-        }
-
-        public double getPreTruncationMessagesLength() {
-            return preTruncationMessagesLength;
-        }
-
-        public void setPreTruncationMessagesLength(double preTruncationMessagesLength) {
-            this.preTruncationMessagesLength = preTruncationMessagesLength;
-        }
-
-        public double getPostTruncationTokensInMessages() {
-            return postTruncationTokensInMessages;
-        }
-
-        public void setPostTruncationTokensInMessages(double postTruncationTokensInMessages) {
-            this.postTruncationTokensInMessages = postTruncationTokensInMessages;
-        }
-
-        public double getPostTruncationMessagesLength() {
-            return postTruncationMessagesLength;
-        }
-
-        public void setPostTruncationMessagesLength(double postTruncationMessagesLength) {
-            this.postTruncationMessagesLength = postTruncationMessagesLength;
-        }
-
-        public double getTokensRemovedDuringTruncation() {
-            return tokensRemovedDuringTruncation;
-        }
-
-        public void setTokensRemovedDuringTruncation(double tokensRemovedDuringTruncation) {
-            this.tokensRemovedDuringTruncation = tokensRemovedDuringTruncation;
-        }
-
-        public double getMessagesRemovedDuringTruncation() {
-            return messagesRemovedDuringTruncation;
-        }
-
-        public void setMessagesRemovedDuringTruncation(double messagesRemovedDuringTruncation) {
-            this.messagesRemovedDuringTruncation = messagesRemovedDuringTruncation;
-        }
-
-        public String getPerformedBy() {
-            return performedBy;
-        }
-
-        public void setPerformedBy(String performedBy) {
-            this.performedBy = performedBy;
-        }
+    public record SessionTruncationData(@JsonProperty("tokenLimit") double tokenLimit,
+            @JsonProperty("preTruncationTokensInMessages") double preTruncationTokensInMessages,
+            @JsonProperty("preTruncationMessagesLength") double preTruncationMessagesLength,
+            @JsonProperty("postTruncationTokensInMessages") double postTruncationTokensInMessages,
+            @JsonProperty("postTruncationMessagesLength") double postTruncationMessagesLength,
+            @JsonProperty("tokensRemovedDuringTruncation") double tokensRemovedDuringTruncation,
+            @JsonProperty("messagesRemovedDuringTruncation") double messagesRemovedDuringTruncation,
+            @JsonProperty("performedBy") String performedBy) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/SessionUsageInfoEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/SessionUsageInfoEvent.java
@@ -32,39 +32,8 @@ public final class SessionUsageInfoEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SessionUsageInfoData {
-
-        @JsonProperty("tokenLimit")
-        private double tokenLimit;
-
-        @JsonProperty("currentTokens")
-        private double currentTokens;
-
-        @JsonProperty("messagesLength")
-        private double messagesLength;
-
-        public double getTokenLimit() {
-            return tokenLimit;
-        }
-
-        public void setTokenLimit(double tokenLimit) {
-            this.tokenLimit = tokenLimit;
-        }
-
-        public double getCurrentTokens() {
-            return currentTokens;
-        }
-
-        public void setCurrentTokens(double currentTokens) {
-            this.currentTokens = currentTokens;
-        }
-
-        public double getMessagesLength() {
-            return messagesLength;
-        }
-
-        public void setMessagesLength(double messagesLength) {
-            this.messagesLength = messagesLength;
-        }
+    public record SessionUsageInfoData(@JsonProperty("tokenLimit") double tokenLimit,
+            @JsonProperty("currentTokens") double currentTokens,
+            @JsonProperty("messagesLength") double messagesLength) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/SubagentCompletedEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/SubagentCompletedEvent.java
@@ -32,28 +32,7 @@ public final class SubagentCompletedEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SubagentCompletedData {
-
-        @JsonProperty("toolCallId")
-        private String toolCallId;
-
-        @JsonProperty("agentName")
-        private String agentName;
-
-        public String getToolCallId() {
-            return toolCallId;
-        }
-
-        public void setToolCallId(String toolCallId) {
-            this.toolCallId = toolCallId;
-        }
-
-        public String getAgentName() {
-            return agentName;
-        }
-
-        public void setAgentName(String agentName) {
-            this.agentName = agentName;
-        }
+    public record SubagentCompletedData(@JsonProperty("toolCallId") String toolCallId,
+            @JsonProperty("agentName") String agentName) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/SubagentFailedEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/SubagentFailedEvent.java
@@ -32,39 +32,7 @@ public final class SubagentFailedEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SubagentFailedData {
-
-        @JsonProperty("toolCallId")
-        private String toolCallId;
-
-        @JsonProperty("agentName")
-        private String agentName;
-
-        @JsonProperty("error")
-        private String error;
-
-        public String getToolCallId() {
-            return toolCallId;
-        }
-
-        public void setToolCallId(String toolCallId) {
-            this.toolCallId = toolCallId;
-        }
-
-        public String getAgentName() {
-            return agentName;
-        }
-
-        public void setAgentName(String agentName) {
-            this.agentName = agentName;
-        }
-
-        public String getError() {
-            return error;
-        }
-
-        public void setError(String error) {
-            this.error = error;
-        }
+    public record SubagentFailedData(@JsonProperty("toolCallId") String toolCallId,
+            @JsonProperty("agentName") String agentName, @JsonProperty("error") String error) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/SubagentStartedEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/SubagentStartedEvent.java
@@ -32,50 +32,8 @@ public final class SubagentStartedEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SubagentStartedData {
-
-        @JsonProperty("toolCallId")
-        private String toolCallId;
-
-        @JsonProperty("agentName")
-        private String agentName;
-
-        @JsonProperty("agentDisplayName")
-        private String agentDisplayName;
-
-        @JsonProperty("agentDescription")
-        private String agentDescription;
-
-        public String getToolCallId() {
-            return toolCallId;
-        }
-
-        public void setToolCallId(String toolCallId) {
-            this.toolCallId = toolCallId;
-        }
-
-        public String getAgentName() {
-            return agentName;
-        }
-
-        public void setAgentName(String agentName) {
-            this.agentName = agentName;
-        }
-
-        public String getAgentDisplayName() {
-            return agentDisplayName;
-        }
-
-        public void setAgentDisplayName(String agentDisplayName) {
-            this.agentDisplayName = agentDisplayName;
-        }
-
-        public String getAgentDescription() {
-            return agentDescription;
-        }
-
-        public void setAgentDescription(String agentDescription) {
-            this.agentDescription = agentDescription;
-        }
+    public record SubagentStartedData(@JsonProperty("toolCallId") String toolCallId,
+            @JsonProperty("agentName") String agentName, @JsonProperty("agentDisplayName") String agentDisplayName,
+            @JsonProperty("agentDescription") String agentDescription) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/ToolExecutionPartialResultEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/ToolExecutionPartialResultEvent.java
@@ -32,28 +32,7 @@ public final class ToolExecutionPartialResultEvent extends AbstractSessionEvent 
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class ToolExecutionPartialResultData {
-
-        @JsonProperty("toolCallId")
-        private String toolCallId;
-
-        @JsonProperty("partialOutput")
-        private String partialOutput;
-
-        public String getToolCallId() {
-            return toolCallId;
-        }
-
-        public void setToolCallId(String toolCallId) {
-            this.toolCallId = toolCallId;
-        }
-
-        public String getPartialOutput() {
-            return partialOutput;
-        }
-
-        public void setPartialOutput(String partialOutput) {
-            this.partialOutput = partialOutput;
-        }
+    public record ToolExecutionPartialResultData(@JsonProperty("toolCallId") String toolCallId,
+            @JsonProperty("partialOutput") String partialOutput) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/ToolExecutionProgressEvent.java
+++ b/src/main/java/com/github/copilot/sdk/events/ToolExecutionProgressEvent.java
@@ -37,30 +37,7 @@ public final class ToolExecutionProgressEvent extends AbstractSessionEvent {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class ToolExecutionProgressData {
-
-        @JsonProperty("toolCallId")
-        private String toolCallId;
-
-        @JsonProperty("progressMessage")
-        private String progressMessage;
-
-        public String getToolCallId() {
-            return toolCallId;
-        }
-
-        public ToolExecutionProgressData setToolCallId(String toolCallId) {
-            this.toolCallId = toolCallId;
-            return this;
-        }
-
-        public String getProgressMessage() {
-            return progressMessage;
-        }
-
-        public ToolExecutionProgressData setProgressMessage(String progressMessage) {
-            this.progressMessage = progressMessage;
-            return this;
-        }
+    public record ToolExecutionProgressData(@JsonProperty("toolCallId") String toolCallId,
+            @JsonProperty("progressMessage") String progressMessage) {
     }
 }

--- a/src/main/java/com/github/copilot/sdk/events/package-info.java
+++ b/src/main/java/com/github/copilot/sdk/events/package-info.java
@@ -70,7 +70,7 @@
  * session.on(evt -> {
  * 	if (evt instanceof AssistantMessageDeltaEvent delta) {
  * 		// Streaming response - print incrementally
- * 		System.out.print(delta.getData().getDeltaContent());
+ * 		System.out.print(delta.getData().deltaContent());
  * 	} else if (evt instanceof AssistantMessageEvent msg) {
  * 		// Complete response
  * 		System.out.println("\nFinal: " + msg.getData().getContent());
@@ -79,7 +79,7 @@
  * 	} else if (evt instanceof SessionIdleEvent) {
  * 		System.out.println("Session is idle");
  * 	} else if (evt instanceof SessionErrorEvent err) {
- * 		System.err.println("Error: " + err.getData().getMessage());
+ * 		System.err.println("Error: " + err.getData().message());
  * 	}
  * });
  * }</pre>

--- a/src/site/markdown/documentation.md
+++ b/src/site/markdown/documentation.md
@@ -72,7 +72,7 @@ session.on(AssistantMessageEvent.class, msg -> {
 });
 
 session.on(SessionErrorEvent.class, err -> {
-    System.err.println("Error: " + err.getData().getMessage());
+    System.err.println("Error: " + err.getData().message());
 });
 
 session.on(SessionIdleEvent.class, idle -> {
@@ -91,7 +91,7 @@ session.on(event -> {
         case AssistantMessageEvent msg -> 
             System.out.println("Response: " + msg.getData().getContent());
         case SessionErrorEvent err -> 
-            System.err.println("Error: " + err.getData().getMessage());
+            System.err.println("Error: " + err.getData().message());
         case SessionIdleEvent idle -> 
             done.complete(null);
         default -> { }
@@ -202,7 +202,7 @@ var done = new CompletableFuture<Void>();
 
 session.on(AssistantMessageDeltaEvent.class, delta -> {
     // Print each chunk as it arrives
-    System.out.print(delta.getData().getDeltaContent());
+    System.out.print(delta.getData().deltaContent());
 });
 
 session.on(SessionIdleEvent.class, idle -> {

--- a/src/site/markdown/getting-started.md
+++ b/src/site/markdown/getting-started.md
@@ -128,7 +128,7 @@ public class StreamingExample {
 
             // Listen for response chunks
             session.on(AssistantMessageDeltaEvent.class, delta -> {
-                System.out.print(delta.getData().getDeltaContent());
+                System.out.print(delta.getData().deltaContent());
             });
             session.on(SessionIdleEvent.class, idle -> {
                 System.out.println(); // New line when done
@@ -204,7 +204,7 @@ public class ToolExample {
             var done = new CompletableFuture<Void>();
 
             session.on(AssistantMessageDeltaEvent.class, delta -> {
-                System.out.print(delta.getData().getDeltaContent());
+                System.out.print(delta.getData().deltaContent());
             });
             session.on(SessionIdleEvent.class, idle -> {
                 System.out.println();
@@ -283,7 +283,7 @@ public class WeatherAssistant {
 
             // Register listener once, outside the loop
             session.on(AssistantMessageDeltaEvent.class, delta -> {
-                System.out.print(delta.getData().getDeltaContent());
+                System.out.print(delta.getData().deltaContent());
             });
             session.on(SessionIdleEvent.class, idle -> {
                 System.out.println();

--- a/src/test/java/com/github/copilot/sdk/CompactionTest.java
+++ b/src/test/java/com/github/copilot/sdk/CompactionTest.java
@@ -103,7 +103,7 @@ public class CompactionTest {
                     .map(e -> (SessionCompactionCompleteEvent) e).reduce((first, second) -> second).orElse(null);
 
             assertNotNull(lastCompactionComplete);
-            assertTrue(lastCompactionComplete.getData().isSuccess(), "Compaction should have succeeded");
+            assertTrue(lastCompactionComplete.getData().success(), "Compaction should have succeeded");
 
             // Verify the session still works after compaction
             AssistantMessageEvent answer = session

--- a/src/test/java/com/github/copilot/sdk/MetadataApiTest.java
+++ b/src/test/java/com/github/copilot/sdk/MetadataApiTest.java
@@ -102,8 +102,8 @@ public class MetadataApiTest {
         ToolExecutionProgressEvent progressEvent = (ToolExecutionProgressEvent) event;
         assertEquals("tool.execution_progress", progressEvent.getType());
         assertNotNull(progressEvent.getData());
-        assertEquals("call-123", progressEvent.getData().getToolCallId());
-        assertEquals("Processing file 1 of 10...", progressEvent.getData().getProgressMessage());
+        assertEquals("call-123", progressEvent.getData().toolCallId());
+        assertEquals("Processing file 1 of 10...", progressEvent.getData().progressMessage());
     }
 
     @Test

--- a/src/test/java/com/github/copilot/sdk/SessionEventHandlingTest.java
+++ b/src/test/java/com/github/copilot/sdk/SessionEventHandlingTest.java
@@ -175,11 +175,11 @@ public class SessionEventHandlingTest {
         });
 
         session.on(SessionStartEvent.class, start -> {
-            capturedSessionId.set(start.getData().getSessionId());
+            capturedSessionId.set(start.getData().sessionId());
         });
 
         SessionStartEvent startEvent = createSessionStartEvent();
-        startEvent.getData().setSessionId("my-session-123");
+        startEvent.setData(new SessionStartEvent.SessionStartData("my-session-123", 0, null, null, null, null));
         dispatchEvent(startEvent);
 
         AssistantMessageEvent msgEvent = createAssistantMessageEvent("Test content");
@@ -851,8 +851,7 @@ public class SessionEventHandlingTest {
     // Factory methods for creating test events
     private SessionStartEvent createSessionStartEvent() {
         var event = new SessionStartEvent();
-        var data = new SessionStartEvent.SessionStartData();
-        data.setSessionId("test-session");
+        var data = new SessionStartEvent.SessionStartData("test-session", 0, null, null, null, null);
         event.setData(data);
         return event;
     }

--- a/src/test/java/com/github/copilot/sdk/SessionEventParserTest.java
+++ b/src/test/java/com/github/copilot/sdk/SessionEventParserTest.java
@@ -59,7 +59,7 @@ public class SessionEventParserTest {
         assertEquals("session.start", event.getType());
 
         var startEvent = (SessionStartEvent) event;
-        assertEquals("sess-123", startEvent.getData().getSessionId());
+        assertEquals("sess-123", startEvent.getData().sessionId());
     }
 
     @Test
@@ -98,9 +98,9 @@ public class SessionEventParserTest {
         assertEquals("session.error", event.getType());
 
         var errorEvent = (SessionErrorEvent) event;
-        assertEquals("RateLimitError", errorEvent.getData().getErrorType());
-        assertEquals("Rate limit exceeded", errorEvent.getData().getMessage());
-        assertNotNull(errorEvent.getData().getStack());
+        assertEquals("RateLimitError", errorEvent.getData().errorType());
+        assertEquals("Rate limit exceeded", errorEvent.getData().message());
+        assertNotNull(errorEvent.getData().stack());
     }
 
     @Test
@@ -136,8 +136,8 @@ public class SessionEventParserTest {
         assertEquals("session.info", event.getType());
 
         var infoEvent = (SessionInfoEvent) event;
-        assertEquals("status", infoEvent.getData().getInfoType());
-        assertEquals("Processing request", infoEvent.getData().getMessage());
+        assertEquals("status", infoEvent.getData().infoType());
+        assertEquals("Processing request", infoEvent.getData().message());
     }
 
     @Test
@@ -316,7 +316,7 @@ public class SessionEventParserTest {
         assertEquals("assistant.turn_start", event.getType());
 
         var turnEvent = (AssistantTurnStartEvent) event;
-        assertEquals("turn-123", turnEvent.getData().getTurnId());
+        assertEquals("turn-123", turnEvent.getData().turnId());
     }
 
     @Test
@@ -354,8 +354,8 @@ public class SessionEventParserTest {
         assertEquals("assistant.reasoning", event.getType());
 
         var reasoningEvent = (AssistantReasoningEvent) event;
-        assertEquals("reason-123", reasoningEvent.getData().getReasoningId());
-        assertEquals("Analyzing the code structure...", reasoningEvent.getData().getContent());
+        assertEquals("reason-123", reasoningEvent.getData().reasoningId());
+        assertEquals("Analyzing the code structure...", reasoningEvent.getData().content());
     }
 
     @Test
@@ -576,8 +576,8 @@ public class SessionEventParserTest {
         assertEquals("subagent.started", event.getType());
 
         var startedEvent = (SubagentStartedEvent) event;
-        assertEquals("code-review", startedEvent.getData().getAgentName());
-        assertEquals("Code Review Agent", startedEvent.getData().getAgentDisplayName());
+        assertEquals("code-review", startedEvent.getData().agentName());
+        assertEquals("Code Review Agent", startedEvent.getData().agentDisplayName());
     }
 
     @Test
@@ -1016,12 +1016,12 @@ public class SessionEventParserTest {
         var event = (SessionStartEvent) parseJson(json);
         assertNotNull(event);
         var data = event.getData();
-        assertEquals("sess-full", data.getSessionId());
-        assertEquals(2.0, data.getVersion());
-        assertEquals("copilot-cli", data.getProducer());
-        assertEquals("1.2.3", data.getCopilotVersion());
-        assertNotNull(data.getStartTime());
-        assertEquals("gpt-4-turbo", data.getSelectedModel());
+        assertEquals("sess-full", data.sessionId());
+        assertEquals(2.0, data.version());
+        assertEquals("copilot-cli", data.producer());
+        assertEquals("1.2.3", data.copilotVersion());
+        assertNotNull(data.startTime());
+        assertEquals("gpt-4-turbo", data.selectedModel());
     }
 
     @Test
@@ -1039,8 +1039,8 @@ public class SessionEventParserTest {
         var event = (SessionResumeEvent) parseJson(json);
         assertNotNull(event);
         var data = event.getData();
-        assertNotNull(data.getResumeTime());
-        assertEquals(42.0, data.getEventCount());
+        assertNotNull(data.resumeTime());
+        assertEquals(42.0, data.eventCount());
     }
 
     @Test
@@ -1061,11 +1061,11 @@ public class SessionEventParserTest {
         var event = (SessionErrorEvent) parseJson(json);
         assertNotNull(event);
         var data = event.getData();
-        assertEquals("InternalError", data.getErrorType());
-        assertEquals("Something went wrong", data.getMessage());
-        assertEquals("at line 42", data.getStack());
-        assertEquals(500, data.getStatusCode());
-        assertEquals("prov-err-1", data.getProviderCallId());
+        assertEquals("InternalError", data.errorType());
+        assertEquals("Something went wrong", data.message());
+        assertEquals("at line 42", data.stack());
+        assertEquals(500, data.statusCode());
+        assertEquals("prov-err-1", data.providerCallId());
     }
 
     @Test
@@ -1082,8 +1082,8 @@ public class SessionEventParserTest {
 
         var event = (SessionModelChangeEvent) parseJson(json);
         assertNotNull(event);
-        assertEquals("gpt-4", event.getData().getPreviousModel());
-        assertEquals("gpt-4o", event.getData().getNewModel());
+        assertEquals("gpt-4", event.getData().previousModel());
+        assertEquals("gpt-4o", event.getData().newModel());
     }
 
     @Test
@@ -1109,15 +1109,15 @@ public class SessionEventParserTest {
         var event = (SessionHandoffEvent) parseJson(json);
         assertNotNull(event);
         var data = event.getData();
-        assertNotNull(data.getHandoffTime());
-        assertEquals("cli", data.getSourceType());
-        assertEquals("additional context", data.getContext());
-        assertEquals("handoff summary", data.getSummary());
-        assertEquals("remote-sess-1", data.getRemoteSessionId());
-        assertNotNull(data.getRepository());
-        assertEquals("my-org", data.getRepository().getOwner());
-        assertEquals("my-repo", data.getRepository().getName());
-        assertEquals("main", data.getRepository().getBranch());
+        assertNotNull(data.handoffTime());
+        assertEquals("cli", data.sourceType());
+        assertEquals("additional context", data.context());
+        assertEquals("handoff summary", data.summary());
+        assertEquals("remote-sess-1", data.remoteSessionId());
+        assertNotNull(data.repository());
+        assertEquals("my-org", data.repository().owner());
+        assertEquals("my-repo", data.repository().name());
+        assertEquals("main", data.repository().branch());
     }
 
     @Test
@@ -1141,14 +1141,14 @@ public class SessionEventParserTest {
         var event = (SessionTruncationEvent) parseJson(json);
         assertNotNull(event);
         var data = event.getData();
-        assertEquals(128000.0, data.getTokenLimit());
-        assertEquals(150000.0, data.getPreTruncationTokensInMessages());
-        assertEquals(100.0, data.getPreTruncationMessagesLength());
-        assertEquals(120000.0, data.getPostTruncationTokensInMessages());
-        assertEquals(80.0, data.getPostTruncationMessagesLength());
-        assertEquals(30000.0, data.getTokensRemovedDuringTruncation());
-        assertEquals(20.0, data.getMessagesRemovedDuringTruncation());
-        assertEquals("system", data.getPerformedBy());
+        assertEquals(128000.0, data.tokenLimit());
+        assertEquals(150000.0, data.preTruncationTokensInMessages());
+        assertEquals(100.0, data.preTruncationMessagesLength());
+        assertEquals(120000.0, data.postTruncationTokensInMessages());
+        assertEquals(80.0, data.postTruncationMessagesLength());
+        assertEquals(30000.0, data.tokensRemovedDuringTruncation());
+        assertEquals(20.0, data.messagesRemovedDuringTruncation());
+        assertEquals("system", data.performedBy());
     }
 
     @Test
@@ -1167,9 +1167,9 @@ public class SessionEventParserTest {
         var event = (SessionUsageInfoEvent) parseJson(json);
         assertNotNull(event);
         var data = event.getData();
-        assertEquals(128000.0, data.getTokenLimit());
-        assertEquals(50000.0, data.getCurrentTokens());
-        assertEquals(25.0, data.getMessagesLength());
+        assertEquals(128000.0, data.tokenLimit());
+        assertEquals(50000.0, data.currentTokens());
+        assertEquals(25.0, data.messagesLength());
     }
 
     @Test
@@ -1201,23 +1201,23 @@ public class SessionEventParserTest {
         var event = (SessionCompactionCompleteEvent) parseJson(json);
         assertNotNull(event);
         var data = event.getData();
-        assertTrue(data.isSuccess());
-        assertNull(data.getError());
-        assertEquals(150000.0, data.getPreCompactionTokens());
-        assertEquals(60000.0, data.getPostCompactionTokens());
-        assertEquals(100.0, data.getPreCompactionMessagesLength());
-        assertEquals(50.0, data.getMessagesRemoved());
-        assertEquals(90000.0, data.getTokensRemoved());
-        assertEquals("Compacted conversation", data.getSummaryContent());
-        assertEquals(3.0, data.getCheckpointNumber());
-        assertEquals("/checkpoints/3", data.getCheckpointPath());
-        assertEquals("req-compact-1", data.getRequestId());
+        assertTrue(data.success());
+        assertNull(data.error());
+        assertEquals(150000.0, data.preCompactionTokens());
+        assertEquals(60000.0, data.postCompactionTokens());
+        assertEquals(100.0, data.preCompactionMessagesLength());
+        assertEquals(50.0, data.messagesRemoved());
+        assertEquals(90000.0, data.tokensRemoved());
+        assertEquals("Compacted conversation", data.summaryContent());
+        assertEquals(3.0, data.checkpointNumber());
+        assertEquals("/checkpoints/3", data.checkpointPath());
+        assertEquals("req-compact-1", data.requestId());
 
-        var tokens = data.getCompactionTokensUsed();
+        var tokens = data.compactionTokensUsed();
         assertNotNull(tokens);
-        assertEquals(1000.0, tokens.getInput());
-        assertEquals(500.0, tokens.getOutput());
-        assertEquals(200.0, tokens.getCachedInput());
+        assertEquals(1000.0, tokens.input());
+        assertEquals(500.0, tokens.output());
+        assertEquals(200.0, tokens.cachedInput());
     }
 
     @Test
@@ -1332,10 +1332,10 @@ public class SessionEventParserTest {
         var event = (AssistantMessageDeltaEvent) parseJson(json);
         assertNotNull(event);
         var data = event.getData();
-        assertEquals("msg-delta-1", data.getMessageId());
-        assertEquals("partial text", data.getDeltaContent());
-        assertEquals(4096.0, data.getTotalResponseSizeBytes());
-        assertEquals("ptc-1", data.getParentToolCallId());
+        assertEquals("msg-delta-1", data.messageId());
+        assertEquals("partial text", data.deltaContent());
+        assertEquals(4096.0, data.totalResponseSizeBytes());
+        assertEquals("ptc-1", data.parentToolCallId());
     }
 
     @Test
@@ -1395,8 +1395,8 @@ public class SessionEventParserTest {
 
         var event = (AssistantReasoningDeltaEvent) parseJson(json);
         assertNotNull(event);
-        assertEquals("r-delta-1", event.getData().getReasoningId());
-        assertEquals("thinking about...", event.getData().getDeltaContent());
+        assertEquals("r-delta-1", event.getData().reasoningId());
+        assertEquals("thinking about...", event.getData().deltaContent());
     }
 
     @Test
@@ -1412,7 +1412,7 @@ public class SessionEventParserTest {
 
         var event = (AssistantIntentEvent) parseJson(json);
         assertNotNull(event);
-        assertEquals("refactor_code", event.getData().getIntent());
+        assertEquals("refactor_code", event.getData().intent());
     }
 
     @Test
@@ -1428,7 +1428,7 @@ public class SessionEventParserTest {
 
         var event = (AssistantTurnEndEvent) parseJson(json);
         assertNotNull(event);
-        assertEquals("turn-end-1", event.getData().getTurnId());
+        assertEquals("turn-end-1", event.getData().turnId());
     }
 
     // =========================================================================
@@ -1540,8 +1540,8 @@ public class SessionEventParserTest {
 
         var event = (ToolExecutionPartialResultEvent) parseJson(json);
         assertNotNull(event);
-        assertEquals("tc-partial-1", event.getData().getToolCallId());
-        assertEquals("partial output data", event.getData().getPartialOutput());
+        assertEquals("tc-partial-1", event.getData().toolCallId());
+        assertEquals("partial output data", event.getData().partialOutput());
     }
 
     @Test
@@ -1558,8 +1558,8 @@ public class SessionEventParserTest {
 
         var event = (ToolExecutionProgressEvent) parseJson(json);
         assertNotNull(event);
-        assertEquals("tc-prog-1", event.getData().getToolCallId());
-        assertEquals("50% done", event.getData().getProgressMessage());
+        assertEquals("tc-prog-1", event.getData().toolCallId());
+        assertEquals("50% done", event.getData().progressMessage());
     }
 
     @Test
@@ -1676,10 +1676,10 @@ public class SessionEventParserTest {
         var event = (SubagentStartedEvent) parseJson(json);
         assertNotNull(event);
         var data = event.getData();
-        assertEquals("tc-sub-1", data.getToolCallId());
-        assertEquals("test-agent", data.getAgentName());
-        assertEquals("Test Agent", data.getAgentDisplayName());
-        assertEquals("A test subagent", data.getAgentDescription());
+        assertEquals("tc-sub-1", data.toolCallId());
+        assertEquals("test-agent", data.agentName());
+        assertEquals("Test Agent", data.agentDisplayName());
+        assertEquals("A test subagent", data.agentDescription());
     }
 
     @Test
@@ -1696,8 +1696,8 @@ public class SessionEventParserTest {
 
         var event = (SubagentCompletedEvent) parseJson(json);
         assertNotNull(event);
-        assertEquals("tc-sub-2", event.getData().getToolCallId());
-        assertEquals("reviewer", event.getData().getAgentName());
+        assertEquals("tc-sub-2", event.getData().toolCallId());
+        assertEquals("reviewer", event.getData().agentName());
     }
 
     @Test
@@ -1715,9 +1715,9 @@ public class SessionEventParserTest {
 
         var event = (SubagentFailedEvent) parseJson(json);
         assertNotNull(event);
-        assertEquals("tc-sub-3", event.getData().getToolCallId());
-        assertEquals("broken-agent", event.getData().getAgentName());
-        assertEquals("Connection timeout", event.getData().getError());
+        assertEquals("tc-sub-3", event.getData().toolCallId());
+        assertEquals("broken-agent", event.getData().agentName());
+        assertEquals("Connection timeout", event.getData().error());
     }
 
     @Test
@@ -1835,7 +1835,7 @@ public class SessionEventParserTest {
 
         var event = (AbortEvent) parseJson(json);
         assertNotNull(event);
-        assertEquals("user_cancelled", event.getData().getReason());
+        assertEquals("user_cancelled", event.getData().reason());
     }
 
     @Test
@@ -1877,8 +1877,8 @@ public class SessionEventParserTest {
 
         var event = (SessionInfoEvent) parseJson(json);
         assertNotNull(event);
-        assertEquals("model_selection", event.getData().getInfoType());
-        assertEquals("Using gpt-4-turbo for this task", event.getData().getMessage());
+        assertEquals("model_selection", event.getData().infoType());
+        assertEquals("Using gpt-4-turbo for this task", event.getData().message());
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Convert 25 simple inner `Data` classes (those with only scalar fields — no `List`, `Map`, or array fields) to Java records across the `events` package. Records provide immutable, concise DTOs with automatic `equals`, `hashCode`, and `toString` implementations. Jackson `@JsonProperty` annotations on constructor parameters preserve JSON deserialization compatibility.

## Changes

### Source files (25 event Data classes + 2 helper records)
- **0-field records**: `PendingMessagesModifiedData`, `SessionCompactionStartData`, `SessionIdleData`
- **1-field records**: `AbortData`, `AssistantIntentData`, `AssistantTurnEndData`, `AssistantTurnStartData`
- **2-field records**: `AssistantReasoningDeltaData`, `AssistantReasoningData`, `SessionInfoData`, `SessionModelChangeData`, `SessionResumeData`, `SessionSnapshotRewindData`, `SubagentCompletedData`, `ToolExecutionPartialResultData`, `ToolExecutionProgressData`
- **3-5 field records**: `SubagentFailedData`, `SubagentStartedData`, `SessionUsageInfoData`, `SessionErrorData`, `AssistantMessageDeltaData`
- **6+ field records**: `SessionStartData`, `SessionTruncationData`, `SessionHandoffData` (with nested `Repository` record), `SessionCompactionCompleteData` (with sibling `CompactionTokensUsed` record)

### Production code
- `CopilotSession.java`: Updated `getMessage()` → `message()` and `getDeltaContent()` → `deltaContent()` accessor calls
- `package-info.java`: Updated Javadoc examples to use record accessors

### Test files
- `SessionEventParserTest.java`: ~80 getter → accessor updates across 88 test methods
- `SessionEventHandlingTest.java`: Updated factory methods to use record constructors
- `CompactionTest.java`, `MetadataApiTest.java`: Updated accessor calls

### Documentation
- `getting-started.md`, `documentation.md`: Updated code examples to use record accessors

## Testing

- All **219 tests pass** with 0 failures and 0 errors
- Spotless formatting applied and verified
- Compilation verified before and after changes