### PR TITLE
Update docs coverage and hooks reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target
 examples-test/
 .merge-env
+blog-copilotsdk/

--- a/src/site/markdown/documentation.md
+++ b/src/site/markdown/documentation.md
@@ -20,6 +20,7 @@ This guide covers common use cases for the Copilot SDK for Java. For complete AP
 - [Message Delivery Mode](#Message_Delivery_Mode)
 - [Session Management](#Session_Management)
 - [SessionConfig Reference](#SessionConfig_Reference)
+    - [Cloning SessionConfig](#Cloning_SessionConfig)
 
 ---
 
@@ -167,6 +168,7 @@ The SDK supports event types organized by category. All events extend `AbstractS
 | `SessionUsageInfoEvent` | `session.usage_info` | Token usage information |
 | `SessionCompactionStartEvent` | `session.compaction_start` | Context compaction started (infinite sessions) |
 | `SessionCompactionCompleteEvent` | `session.compaction_complete` | Context compaction completed |
+| `SessionContextChangedEvent` | `session.context_changed` | Working directory context changed |
 
 ### Assistant Events
 
@@ -644,6 +646,21 @@ Complete list of all `SessionConfig` options for `createSession()`:
 | `skillDirectories` | List&lt;String&gt; | Directories to load skills from | [Skills](advanced.html#Skills_Configuration) |
 | `disabledSkills` | List&lt;String&gt; | Skills to disable by name | [Skills](advanced.html#Skills_Configuration) |
 | `configDir` | String | Custom configuration directory | [Config Dir](advanced.html#Custom_Configuration_Directory) |
+
+### Cloning SessionConfig
+
+Use `clone()` to copy a base configuration before making per-session changes:
+
+```java
+var base = new SessionConfig()
+    .setModel("gpt-4.1")
+    .setStreaming(true);
+
+var derived = base.clone()
+    .setWorkingDirectory("/repo-a");
+```
+
+`clone()` creates a shallow copy. Collection fields are copied into new collection instances, while nested objects/handlers are shared references.
 
 See [SessionConfig](apidocs/com/github/copilot/sdk/json/SessionConfig.html) Javadoc for full details.
 

--- a/src/site/markdown/hooks.md
+++ b/src/site/markdown/hooks.md
@@ -15,6 +15,7 @@ Session hooks allow you to intercept and modify tool execution, user prompts, an
 | [User Prompt Submitted](#User_Prompt_Submitted_Hook) | When user sends a message | Nothing (observation only) |
 | [Session Start](#Session_Start_Hook) | When session begins | Nothing (observation only) |
 | [Session End](#Session_End_Hook) | When session ends | Nothing (observation only) |
+| [Checking Whether Hooks Are Registered](#Checking_Whether_Hooks_Are_Registered) | Before session creation | Whether any handlers are configured |
 
 ---
 
@@ -133,7 +134,7 @@ Called **after** a tool executes. Use this to:
 |-------|------|-------------|
 | `getToolName()` | `String` | Name of the tool that was called |
 | `getToolArgs()` | `JsonNode` | Arguments that were passed |
-| `getToolResult()` | `String` | Result from the tool |
+| `getToolResult()` | `JsonNode` | Result from the tool |
 | `getCwd()` | `String` | Current working directory |
 | `getTimestamp()` | `long` | Timestamp in milliseconds |
 
@@ -188,7 +189,7 @@ Called when the user submits a prompt, before the LLM processes it. This is an o
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `getPrompt()` | `String` | The user's prompt text |
+| `prompt()` | `String` | The user's prompt text |
 | `getTimestamp()` | `long` | Timestamp in milliseconds |
 
 ### Output
@@ -222,7 +223,7 @@ Called when a session starts (either new or resumed).
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `getSource()` | `String` | `"new"` or `"resumed"` |
+| `source()` | `String` | `"startup"`, `"resume"`, or `"new"` |
 | `getTimestamp()` | `long` | Timestamp in milliseconds |
 
 ### Output
@@ -254,7 +255,7 @@ Called when a session ends.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `getReason()` | `String` | Why the session ended |
+| `reason()` | `String` | Why the session ended |
 | `getTimestamp()` | `long` | Timestamp in milliseconds |
 
 ### Output
@@ -357,6 +358,22 @@ All hook handlers receive a `HookInvocation` object as the second parameter:
 | `getSessionId()` | The session ID where the hook was triggered |
 
 This allows you to correlate hooks with specific sessions when managing multiple concurrent sessions.
+
+## Checking Whether Hooks Are Registered
+
+Use `hasHooks()` to quickly verify that at least one hook handler is configured:
+
+```java
+var hooks = new SessionHooks()
+    .setOnPreToolUse((input, invocation) ->
+        CompletableFuture.completedFuture(PreToolUseHookOutput.allow()));
+
+if (hooks.hasHooks()) {
+    var session = client.createSession(
+        new SessionConfig().setHooks(hooks)
+    ).get();
+}
+```
 
 ---
 


### PR DESCRIPTION
## Summary
Improve SDK documentation coverage alignment with current implementation and add discoverability links for newly documented sections.

## Changes
- Update event reference docs to include `SessionContextChangedEvent` (`session.context_changed`).
- Fix hook API documentation drift in `hooks.md`:
  - Correct record accessor names (`prompt()`, `source()`, `reason()`).
  - Correct `getToolResult()` type to `JsonNode`.
  - Add `startup` to session start source values.
- Add docs for:
  - `SessionConfig.clone()` behavior and usage example.
  - `SessionHooks.hasHooks()` usage example.
- Add navigation links:
  - TOC link for `Cloning SessionConfig` in `documentation.md`.
  - Overview link for `Checking Whether Hooks Are Registered` in `hooks.md`.
- Update `.gitignore` to ignore `blog-copilotsdk/`.

## Testing
- Validation scope: documentation and `.gitignore` changes only.
- Build/test execution: skipped (`mvn clean verify`) because no Java source/test files changed.
- Verified by inspection that links and section anchors are present in updated markdown files.