### PR TITLE
Upgrade Jackson to 2.21.1 to fix async parser DoS vulnerability (GHSA-72hv-8253-57qq)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,17 +49,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.20.1</version>
+            <version>2.21.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.20</version>
+            <version>2.21</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.20.1</version>
+            <version>2.21.1</version>
         </dependency>
 
         <!-- SpotBugs annotations for suppressing warnings -->


### PR DESCRIPTION
## Summary

Fixes [Dependabot alert #1](https://github.com/copilot-community-sdk/copilot-sdk-java/security/dependabot/1) — **GHSA-72hv-8253-57qq** (High severity).

The non-blocking (async) JSON parser in `jackson-core` bypasses the `maxNumberLength` constraint, allowing an attacker to send arbitrarily long numbers causing excessive memory allocation and CPU exhaustion (DoS).

## Changes

Upgrades all Jackson dependencies to the patched versions:

| Dependency | Before | After |
|---|---|---|
| `jackson-databind` | 2.20.1 | 2.21.1 |
| `jackson-annotations` | 2.20 | 2.21 |
| `jackson-datatype-jsr310` | 2.20.1 | 2.21.1 |

## Verification

All 396 tests pass with the upgraded dependencies (`mvn verify` — BUILD SUCCESS).